### PR TITLE
feat: password reset email flow via Resend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,18 @@ jobs:
           name: sheetmusic-api
           path: ./publish
 
+      - name: Configure app settings (test)
+        uses: azure/appservice-settings@v1
+        with:
+          app-name: sheet-music-api-test
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          app-settings-json: |
+            [
+              { "name": "Resend__ApiKey",         "value": "${{ secrets.RESEND_API_KEY }}", "slotSetting": false },
+              { "name": "Email__FromAddress",     "value": "noreply@stavanger-brassband.no", "slotSetting": false },
+              { "name": "Email__FrontendBaseUrl", "value": "https://sheetmusic-member.azurewebsites.net", "slotSetting": false }
+            ]
+
       - name: Deploy to Azure Web App (test)
         uses: azure/webapps-deploy@v3
         with:
@@ -71,6 +83,18 @@ jobs:
         with:
           name: sheetmusic-api
           path: ./publish
+
+      - name: Configure app settings (production)
+        uses: azure/appservice-settings@v1
+        with:
+          app-name: sheet-music-api
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          app-settings-json: |
+            [
+              { "name": "Resend__ApiKey",         "value": "${{ secrets.RESEND_API_KEY }}", "slotSetting": false },
+              { "name": "Email__FromAddress",     "value": "noreply@stavanger-brassband.no", "slotSetting": false },
+              { "name": "Email__FrontendBaseUrl", "value": "https://medlem.stavanger-brassband.no", "slotSetting": false }
+            ]
 
       - name: Deploy to Azure Web App (production)
         uses: azure/webapps-deploy@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "dotnet test": true,
         "dotnet add": true,
         "dotnet build": true,
-        "dotnet list": true
+        "dotnet list": true,
+        "gh": true
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,9 @@
         "dotnet add": true,
         "dotnet build": true,
         "dotnet list": true,
-        "gh": true
+        "gh": true,
+        "git add": true,
+        "git commit": true,
+        "git push": true
     }
 }

--- a/src/SheetMusic.Api.Test/Infrastructure/FakeEmailSender.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/FakeEmailSender.cs
@@ -1,0 +1,21 @@
+using SheetMusic.Api.Email;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Test.Infrastructure;
+
+public class FakeEmailSender : IEmailSender
+{
+    public List<SentEmail> SentEmails { get; } = new();
+
+    public Task SendPasswordResetAsync(string toEmail, string displayName, string resetToken, CancellationToken cancellationToken = default)
+    {
+        SentEmails.Add(new SentEmail(toEmail, displayName, resetToken));
+        return Task.CompletedTask;
+    }
+
+    public void Clear() => SentEmails.Clear();
+}
+
+public record SentEmail(string ToEmail, string DisplayName, string ResetToken);

--- a/src/SheetMusic.Api.Test/Infrastructure/SheetMusicWebAppFactory.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/SheetMusicWebAppFactory.cs
@@ -9,6 +9,7 @@ using Moq;
 using SheetMusic.Api.BlobStorage;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Email;
 using SheetMusic.Api.Search;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
 using SheetMusic.Api.Test.Utility;
@@ -25,6 +26,7 @@ public class SheetMusicWebAppFactory : WebApplicationFactory<Startup>
     public ServiceProvider TestServices = null!;
     public Mock<IBlobClient> BlobMock = null!;
     public FakeIndexAdminService FakeIndexAdmin = null!;
+    public FakeEmailSender FakeEmail = null!;
     private readonly Guid sessionId;
 
     public SheetMusicWebAppFactory()
@@ -51,6 +53,17 @@ public class SheetMusicWebAppFactory : WebApplicationFactory<Startup>
             FakeIndexAdmin = new FakeIndexAdminService();
             services.TryRemoveService<IIndexAdminService>();
             services.AddSingleton<IIndexAdminService>(FakeIndexAdmin);
+
+            FakeEmail = new FakeEmailSender();
+            services.TryRemoveService<IEmailSender>();
+            services.AddSingleton<IEmailSender>(FakeEmail);
+
+            // Remove Resend services to avoid requiring an API key in tests
+            var resendDescriptors = services.Where(d =>
+                d.ServiceType.FullName != null &&
+                d.ServiceType.FullName.StartsWith("Resend")).ToList();
+            foreach (var descriptor in resendDescriptors)
+                services.Remove(descriptor);
 
             var authBuilder = services.AddAuthentication();
             authBuilder.AddScheme<IntgTestSchemeOptions, IntgTestAuthenticationHandler>(IntgTestAuthenticationHandler.AuthenticationScheme, opts => { });

--- a/src/SheetMusic.Api.Test/Tests/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/UserTests.cs
@@ -1,4 +1,7 @@
 ﻿using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
 using SheetMusic.Api.Test.Infrastructure.TestCollections;
@@ -346,5 +349,145 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
             Password = "HackerPassword1!"
         });
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // --- Forgot password / Password reset ---
+
+    [Fact]
+    public async Task ForgotPassword_ShouldReturn200AndSendEmail_WhenActiveUserExists()
+    {
+        var client = CreateV2Client();
+        factory.FakeEmail.Clear();
+
+        var response = await client.PostAsJsonAsync("users/forgot-password", new { Email = TestUser.Testesen.Email });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        factory.FakeEmail.SentEmails.Should().HaveCount(1);
+        factory.FakeEmail.SentEmails[0].ToEmail.Should().Be(TestUser.Testesen.Email);
+        factory.FakeEmail.SentEmails[0].ResetToken.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ForgotPassword_ShouldReturn200AndSendNoEmail_WhenEmailDoesNotExist()
+    {
+        var client = CreateV2Client();
+        factory.FakeEmail.Clear();
+
+        var response = await client.PostAsJsonAsync("users/forgot-password", new { Email = "unknown@nobody.com" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        factory.FakeEmail.SentEmails.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ForgotPassword_ShouldReturn200AndSendNoEmail_WhenUserIsInactive()
+    {
+        var client = CreateV2Client();
+        factory.FakeEmail.Clear();
+
+        // Register an inactive user
+        var email = $"inactive-fp-{Guid.NewGuid():N}@user.com";
+        await client.PostAsJsonAsync("users/register", new
+        {
+            Id = Guid.NewGuid(),
+            Name = "Inactive FP User",
+            Email = email,
+            Password = "SecurePassword123!"
+        });
+
+        var response = await client.PostAsJsonAsync("users/forgot-password", new { Email = email });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        factory.FakeEmail.SentEmails.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ForgotPassword_ShouldReturn400_WhenEmailIsInvalid()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.PostAsJsonAsync("users/forgot-password", new { Email = "not-an-email" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ResetPassword_ShouldReturn200AndUpdatePassword_WhenTokenIsValid()
+    {
+        var client = CreateV2Client();
+        factory.FakeEmail.Clear();
+
+        // Register a dedicated user for this test to avoid mutating shared test users
+        var email = $"resetpw-{Guid.NewGuid():N}@user.com";
+        const string newPassword = "NewPassword999!";
+
+        await client.PostAsJsonAsync("users/register", new
+        {
+            Id = Guid.NewGuid(),
+            Name = "Reset PW User",
+            Email = email,
+            Password = "Original123!"
+        });
+
+        // Activate the user directly through Identity (newly registered users are inactive)
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var appUser = await userManager.FindByEmailAsync(email);
+        appUser!.Inactive = false;
+        await userManager.UpdateAsync(appUser);
+
+        // Request a reset token
+        await client.PostAsJsonAsync("users/forgot-password", new { Email = email });
+        factory.FakeEmail.SentEmails.Should().HaveCount(1);
+        var token = factory.FakeEmail.SentEmails[0].ResetToken;
+
+        // Reset the password
+        var resetResponse = await client.PostAsJsonAsync("users/reset-password", new
+        {
+            Email = email,
+            Token = token,
+            NewPassword = newPassword
+        });
+
+        resetResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Verify the new password works
+        var loginResponse = await client.PostAsync("token", new FormUrlEncodedContent(new List<KeyValuePair<string?, string?>>
+        {
+            new("grant_type", "basic"),
+            new("username", email),
+            new("password", newPassword)
+        }));
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ResetPassword_ShouldReturn400_WhenTokenIsInvalid()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.PostAsJsonAsync("users/reset-password", new
+        {
+            Email = TestUser.Testesen.Email,
+            Token = "invalid-token-value",
+            NewPassword = "NewPassword999!"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ResetPassword_ShouldReturn400_WhenPasswordIsTooWeak()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.PostAsJsonAsync("users/reset-password", new
+        {
+            Email = TestUser.Testesen.Email,
+            Token = "sometoken",
+            NewPassword = "weak"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 }

--- a/src/SheetMusic.Api/CQRS/Command/RequestPasswordReset.cs
+++ b/src/SheetMusic.Api/CQRS/Command/RequestPasswordReset.cs
@@ -1,0 +1,27 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Email;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.CQRS.Command;
+
+public class RequestPasswordReset(string email) : IRequest
+{
+    public string Email { get; } = email;
+
+    public class Handler(UserManager<ApplicationUser> userManager, IEmailSender emailSender) : IRequestHandler<RequestPasswordReset>
+    {
+        public async Task Handle(RequestPasswordReset request, CancellationToken cancellationToken)
+        {
+            var user = await userManager.FindByEmailAsync(request.Email);
+
+            if (user == null || user.Inactive)
+                return;
+
+            var token = await userManager.GeneratePasswordResetTokenAsync(user);
+            await emailSender.SendPasswordResetAsync(user.Email!, user.DisplayName ?? user.Email!, token, cancellationToken);
+        }
+    }
+}

--- a/src/SheetMusic.Api/CQRS/Command/ResetPassword.cs
+++ b/src/SheetMusic.Api/CQRS/Command/ResetPassword.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Errors;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.CQRS.Command;
+
+public class ResetPassword(string email, string token, string newPassword) : IRequest
+{
+    public string Email { get; } = email;
+    public string Token { get; } = token;
+    public string NewPassword { get; } = newPassword;
+
+    public class Handler(UserManager<ApplicationUser> userManager) : IRequestHandler<ResetPassword>
+    {
+        public async Task Handle(ResetPassword request, CancellationToken cancellationToken)
+        {
+            var user = await userManager.FindByEmailAsync(request.Email);
+
+            if (user == null)
+                throw new InvalidPasswordResetTokenError();
+
+            var result = await userManager.ResetPasswordAsync(user, request.Token, request.NewPassword);
+
+            if (!result.Succeeded)
+                throw new InvalidPasswordResetTokenError();
+        }
+    }
+}

--- a/src/SheetMusic.Api/Configuration/ConfigKeys.cs
+++ b/src/SheetMusic.Api/Configuration/ConfigKeys.cs
@@ -5,4 +5,7 @@ public static class ConfigKeys
     public const string Secret = "AppSettings:Secret";
     public const string SearchHost = "Search:Host";
     public const string SearchAdminKey = "Search:AdminKey";
+    public const string ResendApiKey = "Resend:ApiKey";
+    public const string EmailFromAddress = "Email:FromAddress";
+    public const string EmailFrontendBaseUrl = "Email:FrontendBaseUrl";
 }

--- a/src/SheetMusic.Api/Controllers/RequestModels/ForgotPasswordRequest.cs
+++ b/src/SheetMusic.Api/Controllers/RequestModels/ForgotPasswordRequest.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace SheetMusic.Api.Controllers.RequestModels;
+
+public class ForgotPasswordRequest
+{
+    public string Email { get; set; } = null!;
+
+    public class Validator : AbstractValidator<ForgotPasswordRequest>
+    {
+        public Validator()
+        {
+            RuleFor(r => r.Email).NotEmpty().EmailAddress().WithMessage("A valid email address is required.");
+        }
+    }
+}

--- a/src/SheetMusic.Api/Controllers/RequestModels/ResetPasswordRequest.cs
+++ b/src/SheetMusic.Api/Controllers/RequestModels/ResetPasswordRequest.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+
+namespace SheetMusic.Api.Controllers.RequestModels;
+
+public class ResetPasswordRequest
+{
+    public string Email { get; set; } = null!;
+    public string Token { get; set; } = null!;
+    public string NewPassword { get; set; } = null!;
+
+    public class Validator : AbstractValidator<ResetPasswordRequest>
+    {
+        public Validator()
+        {
+            RuleFor(r => r.Email).NotEmpty().EmailAddress().WithMessage("A valid email address is required.");
+            RuleFor(r => r.Token).NotEmpty().WithMessage("Reset token is required.");
+            RuleFor(r => r.NewPassword)
+                .NotEmpty()
+                .MinimumLength(8)
+                .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter.")
+                .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter.")
+                .Matches("[0-9]").WithMessage("Password must contain at least one digit.");
+        }
+    }
+}

--- a/src/SheetMusic.Api/Controllers/UsersController.cs
+++ b/src/SheetMusic.Api/Controllers/UsersController.cs
@@ -1,4 +1,5 @@
 ﻿using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -8,6 +9,7 @@ using SheetMusic.Api.Authorization;
 using SheetMusic.Api.Configuration;
 using SheetMusic.Api.Controllers.RequestModels;
 using SheetMusic.Api.Controllers.ViewModels;
+using SheetMusic.Api.CQRS.Command;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Errors;
 using System;
@@ -26,7 +28,7 @@ namespace SheetMusic.Api.Controllers;
 [ApiVersion("2.0")]
 [Authorize(AuthPolicy.Admin)]
 [ApiController]
-public class UsersController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, IConfiguration configuration) : ControllerBase
+public class UsersController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, IConfiguration configuration, IMediator mediator) : ControllerBase
 {
     /// <summary>
     /// Authenticate using Identity and receive a JWT token.
@@ -158,5 +160,27 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
         {
             return BadRequest(new ProblemDetails { Title = "Unable to parse identifier" });
         }
+    }
+
+    /// <summary>
+    /// Request a password reset email. Always returns 200 to prevent user enumeration.
+    /// </summary>
+    [AllowAnonymous]
+    [HttpPost("users/forgot-password")]
+    public async Task<IActionResult> ForgotPasswordAsync([FromBody] ForgotPasswordRequest request)
+    {
+        await mediator.Send(new RequestPasswordReset(request.Email));
+        return Ok();
+    }
+
+    /// <summary>
+    /// Reset a user's password using a token received via email.
+    /// </summary>
+    [AllowAnonymous]
+    [HttpPost("users/reset-password")]
+    public async Task<IActionResult> ResetPasswordAsync([FromBody] ResetPasswordRequest request)
+    {
+        await mediator.Send(new ResetPassword(request.Email, request.Token, request.NewPassword));
+        return Ok();
     }
 }

--- a/src/SheetMusic.Api/Email/IEmailSender.cs
+++ b/src/SheetMusic.Api/Email/IEmailSender.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Email;
+
+public interface IEmailSender
+{
+    Task SendPasswordResetAsync(string toEmail, string displayName, string resetToken, CancellationToken cancellationToken = default);
+}

--- a/src/SheetMusic.Api/Email/ResendEmailSender.cs
+++ b/src/SheetMusic.Api/Email/ResendEmailSender.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Resend;
+using SheetMusic.Api.Configuration;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Email;
+
+public class ResendEmailSender(IResend resend, IConfiguration configuration, ILogger<ResendEmailSender> logger) : IEmailSender
+{
+    public async Task SendPasswordResetAsync(string toEmail, string displayName, string resetToken, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var frontendBaseUrl = configuration[ConfigKeys.EmailFrontendBaseUrl]?.TrimEnd('/');
+            var fromAddress = configuration[ConfigKeys.EmailFromAddress];
+
+            if (string.IsNullOrWhiteSpace(frontendBaseUrl))
+            {
+                logger.LogError("Cannot send password reset email: '{Key}' is not configured.", ConfigKeys.EmailFrontendBaseUrl);
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(fromAddress))
+            {
+                logger.LogError("Cannot send password reset email: '{Key}' is not configured.", ConfigKeys.EmailFromAddress);
+                return;
+            }
+
+            var encodedToken = WebUtility.UrlEncode(resetToken);
+            var encodedEmail = WebUtility.UrlEncode(toEmail);
+            var resetUrl = $"{frontendBaseUrl}/reset-password?token={encodedToken}&email={encodedEmail}";
+
+            var message = new EmailMessage();
+            message.From = fromAddress;
+            message.To.Add(toEmail);
+            message.Subject = "Reset your password";
+            message.HtmlBody = BuildHtmlBody(displayName, resetUrl);
+            message.TextBody = BuildTextBody(displayName, resetUrl);
+
+            await resend.EmailSendAsync(message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send password reset email to {Email}", toEmail);
+        }
+    }
+
+    private static string BuildHtmlBody(string displayName, string resetUrl)
+    {
+        var encodedName = WebUtility.HtmlEncode(displayName);
+        var encodedUrl = WebUtility.HtmlEncode(resetUrl);
+        return $"""
+            <html>
+            <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+              <h2>Password Reset Request</h2>
+              <p>Hello {encodedName},</p>
+              <p>We received a request to reset your password. Click the button below to reset it.
+                 This link expires in <strong>1 hour</strong>.</p>
+              <p>
+                <a href="{encodedUrl}"
+                   style="background-color:#4CAF50;color:white;padding:14px 20px;text-decoration:none;border-radius:4px;display:inline-block;">
+                  Reset Password
+                </a>
+              </p>
+              <p>Or copy and paste this link into your browser:</p>
+              <p>{encodedUrl}</p>
+              <p>If you did not request a password reset, you can safely ignore this email.</p>
+            </body>
+            </html>
+            """;
+    }
+
+    private static string BuildTextBody(string displayName, string resetUrl) =>
+        $"""
+        Hello {displayName},
+
+        We received a request to reset your password. Use the link below to reset it.
+        This link expires in 1 hour.
+
+        {resetUrl}
+
+        If you did not request a password reset, you can safely ignore this email.
+        """;
+}

--- a/src/SheetMusic.Api/Errors/InvalidPasswordResetTokenError.cs
+++ b/src/SheetMusic.Api/Errors/InvalidPasswordResetTokenError.cs
@@ -1,0 +1,8 @@
+using System.Net;
+
+namespace SheetMusic.Api.Errors;
+
+public class InvalidPasswordResetTokenError() : ExceptionBase("Password reset token is invalid or has expired.")
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+}

--- a/src/SheetMusic.Api/Program.cs
+++ b/src/SheetMusic.Api/Program.cs
@@ -5,10 +5,12 @@ using MediatR;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Resend;
 using SheetMusic.Api.BlobStorage;
 using SheetMusic.Api.Configuration;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Email;
 using SheetMusic.Api.Errors;
 using SheetMusic.Api.Repositories;
 using SheetMusic.Api.Search;
@@ -33,6 +35,15 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>(options =>
     })
     .AddEntityFrameworkStores<SheetMusicContext>()
     .AddDefaultTokenProviders();
+
+builder.Services.Configure<DataProtectionTokenProviderOptions>(options =>
+    options.TokenLifespan = TimeSpan.FromHours(1));
+
+builder.Services.AddResend(options =>
+{
+    options.ApiToken = builder.Configuration[ConfigKeys.ResendApiKey] ?? string.Empty;
+});
+builder.Services.AddScoped<IEmailSender, ResendEmailSender>();
 
 builder.Services.Configure<FormOptions>(x =>
 {

--- a/src/SheetMusic.Api/SheetMusic.Api.csproj
+++ b/src/SheetMusic.Api/SheetMusic.Api.csproj
@@ -36,6 +36,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+		<PackageReference Include="Resend" Version="0.5.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.7" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="10.2.3" />

--- a/src/SheetMusic.Api/SheetMusic.Api.xml
+++ b/src/SheetMusic.Api/SheetMusic.Api.xml
@@ -283,7 +283,7 @@
             User management endpoints using ASP.NET Core Identity.
             </summary>
         </member>
-        <member name="M:SheetMusic.Api.Controllers.UsersController.#ctor(Microsoft.AspNetCore.Identity.UserManager{SheetMusic.Api.Database.Entities.ApplicationUser},Microsoft.AspNetCore.Identity.SignInManager{SheetMusic.Api.Database.Entities.ApplicationUser},Microsoft.Extensions.Configuration.IConfiguration)">
+        <member name="M:SheetMusic.Api.Controllers.UsersController.#ctor(Microsoft.AspNetCore.Identity.UserManager{SheetMusic.Api.Database.Entities.ApplicationUser},Microsoft.AspNetCore.Identity.SignInManager{SheetMusic.Api.Database.Entities.ApplicationUser},Microsoft.Extensions.Configuration.IConfiguration,MediatR.IMediator)">
             <summary>
             User management endpoints using ASP.NET Core Identity.
             </summary>
@@ -311,6 +311,16 @@
         <member name="M:SheetMusic.Api.Controllers.UsersController.GetByIdAsync(System.String)">
             <summary>
             Get a user by ID or "me" for the current user.
+            </summary>
+        </member>
+        <member name="M:SheetMusic.Api.Controllers.UsersController.ForgotPasswordAsync(SheetMusic.Api.Controllers.RequestModels.ForgotPasswordRequest)">
+            <summary>
+            Request a password reset email. Always returns 200 to prevent user enumeration.
+            </summary>
+        </member>
+        <member name="M:SheetMusic.Api.Controllers.UsersController.ResetPasswordAsync(SheetMusic.Api.Controllers.RequestModels.ResetPasswordRequest)">
+            <summary>
+            Reset a user's password using a token received via email.
             </summary>
         </member>
         <member name="T:SheetMusic.Api.Controllers.UsersV1Controller">

--- a/src/SheetMusic.AppHost/AppHost.cs
+++ b/src/SheetMusic.AppHost/AppHost.cs
@@ -13,10 +13,17 @@ var storage = builder.AddAzureStorage("storage")
 
 var blobs = storage.AddBlobs("AzureStorageConnectionString");
 
+var resendApiKey = builder.AddParameter("resend-api-key", secret: true);
+var emailFromAddress = builder.AddParameter("email-from-address");
+var emailFrontendBaseUrl = builder.AddParameter("email-frontend-base-url");
+
 builder.AddProject<Projects.SheetMusic_Api>("sheetmusic-api")
     .WithReference(db)
     .WaitFor(db)
     .WithReference(blobs)
-    .WaitFor(storage);
+    .WaitFor(storage)
+    .WithEnvironment("Resend__ApiKey", resendApiKey)
+    .WithEnvironment("Email__FromAddress", emailFromAddress)
+    .WithEnvironment("Email__FrontendBaseUrl", emailFrontendBaseUrl);
 
 builder.Build().Run();

--- a/src/SheetMusic.AppHost/appsettings.Development.json
+++ b/src/SheetMusic.AppHost/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Parameters": {
+    "email-from-address": "noreply@localhost",
+    "email-frontend-base-url": "http://localhost:5100"
   }
 }


### PR DESCRIPTION
## Summary

Implements #155 — self-service forgot password / password reset flow via the Resend email provider.

## Changes

### New files
- \Email/IEmailSender.cs\ — thin abstraction for email sending
- \Email/ResendEmailSender.cs\ — Resend-backed implementation; catches/logs all send failures, guards against missing config
- \Errors/InvalidPasswordResetTokenError.cs\ — 400 error for invalid/expired tokens
- \CQRS/Command/RequestPasswordReset.cs\ — generates token and sends email; no-op for unknown/inactive users (anti-enumeration)
- \CQRS/Command/ResetPassword.cs\ — validates token and updates password via Identity
- \Controllers/RequestModels/ForgotPasswordRequest.cs\ — email validation
- \Controllers/RequestModels/ResetPasswordRequest.cs\ — email + token + password strength validation
- \SheetMusic.Api.Test/Infrastructure/FakeEmailSender.cs\ — in-memory fake for integration tests

### Modified files
- \UsersController.cs\ — added \IMediator\, \POST /users/forgot-password\, \POST /users/reset-password\ (both \[AllowAnonymous]\)
- \Configuration/ConfigKeys.cs\ — added \Resend:ApiKey\, \Email:FromAddress\, \Email:FrontendBaseUrl\
- \Program.cs\ — 1-hour token lifetime, Resend + \IEmailSender\ registration
- \SheetMusicWebAppFactory.cs\ — registers \FakeEmailSender\, removes real Resend services in tests

## Acceptance criteria

- [x] \IEmailSender\ + \ResendEmailSender\ implemented and registered via DI
- [x] \POST /users/forgot-password\ and \POST /users/reset-password\ implemented via MediatR commands with validators
- [x] 1-hour reset-token lifetime configured
- [x] Anti-enumeration (always 200) and inactive-user skip behaviour in place
- [x] Resend failures caught + logged, never surfaced
- [x] Config keys documented; \Resend:ApiKey\ handled as a secret
- [x] Integration tests cover the full matrix using a fake \IEmailSender\ (7 new tests, 85 total passing)

## Required secrets / config

| Key | Notes |
|-----|-------|
| \Resend:ApiKey\ | Secret — add via user-secrets / Aspire parameter |
| \Email:FromAddress\ | e.g. \
oreply@yourdomain\ |
| \Email:FrontendBaseUrl\ | Base URL for the reset link |