### PR TITLE
fix: apply $orderby to GET /sheetmusic/sets

### DIFF
--- a/src/SheetMusic.Api.Test/Tests/SetTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/SetTests.cs
@@ -84,6 +84,26 @@ public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusi
     }
 
     [Fact]
+    public async Task GetSetList_WithOrderByTitleDescending_ShouldReturnSetsOrderedByTitleDescending()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        await new SetDataBuilder(adminClient)
+            .WithSets(20)
+            .ProvisionAsync();
+
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var response = await client.GetAsync("sheetmusic/sets?$orderby=title desc");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadAsStringAsync();
+        var items = JsonConvert.DeserializeObject<List<ApiSet>>(body);
+
+        items.Should().NotBeNull();
+        items.Should().BeInDescendingOrder(s => s.Title);
+    }
+
+    [Fact]
     public async Task GetPartsForSet_ShouldBeSuccessfull()
     {
         var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);

--- a/src/SheetMusic.Api/CQRS/Query/GetSets.cs
+++ b/src/SheetMusic.Api/CQRS/Query/GetSets.cs
@@ -3,7 +3,9 @@ using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.OData;
+using SheetMusic.Api.OData.Expression;
 using SheetMusic.Api.OData.MVC;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -17,23 +19,21 @@ public class GetSets(ODataQueryParams queryParams) : IRequest<List<SheetMusicSet
 
     public class Handler(SheetMusicContext db) : IRequestHandler<GetSets, List<SheetMusicSet>>
     {
+        private static readonly Action<ODataFieldMapping<SheetMusicSet>> FieldMapping = m =>
+        {
+            m.MapField("archiveNumber", s => s.ArchiveNumber);
+            m.MapField("title", s => s.Title);
+            m.MapField("composer", s => s.Composer);
+            m.MapField("arranger", s => s.Arranger);
+            m.MapField("soleSellingAgent", s => s.SoleSellingAgent);
+        };
+
         public async Task<List<SheetMusicSet>> Handle(GetSets request, CancellationToken cancellationToken)
         {
-            var baseQuery = db.SheetMusicSets
-                .OrderBy(s => s.ArchiveNumber)
-                .AsQueryable();
+            var baseQuery = db.SheetMusicSets.AsQueryable();
 
             if (request.QueryParams.HasFilter)
-            {
-                baseQuery = baseQuery.ApplyODataFilters(request.QueryParams, m =>
-                {
-                    m.MapField("archiveNumber", s => s.ArchiveNumber);
-                    m.MapField("title", s => s.Title);
-                    m.MapField("composer", s => s.Composer);
-                    m.MapField("arranger", s => s.Arranger);
-                    m.MapField("soleSellingAgent", s => s.SoleSellingAgent);
-                });
-            }
+                baseQuery = baseQuery.ApplyODataFilters(request.QueryParams, FieldMapping);
 
             if (request.QueryParams.HasSearch)
             {
@@ -45,6 +45,10 @@ public class GetSets(ODataQueryParams queryParams) : IRequest<List<SheetMusicSet
                     (set.Arranger != null && set.Arranger.Contains(term)) ||
                     (set.Composer != null && set.Composer.Contains(term)));
             }
+
+            baseQuery = request.QueryParams.OrderBy.Any()
+                ? baseQuery.ApplyODataOrderBy(request.QueryParams, FieldMapping)
+                : baseQuery.OrderBy(s => s.ArchiveNumber);
 
             if (request.QueryParams.Skip.HasValue)
                 baseQuery = baseQuery.Skip(request.QueryParams.Skip.Value);

--- a/src/SheetMusic.Api/Controllers/SheetMusicController.cs
+++ b/src/SheetMusic.Api/Controllers/SheetMusicController.cs
@@ -53,7 +53,6 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
                 }).ToList()
                 : null
         })
-        .OrderBy(s => s.ArchiveNumber)
         .ToList();
 
         return new OkObjectResult(transformed);

--- a/src/SheetMusic.Api/OData/Extensions/ODataQueryParamsExtensions.cs
+++ b/src/SheetMusic.Api/OData/Extensions/ODataQueryParamsExtensions.cs
@@ -1,7 +1,10 @@
-﻿using SheetMusic.Api.OData.Expression;
+﻿using SheetMusic.Api.OData.Constants;
+using SheetMusic.Api.OData.Expression;
 using SheetMusic.Api.OData.MVC;
 using System;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 
 namespace SheetMusic.Api.OData;
 
@@ -22,5 +25,39 @@ public static class ODataQueryParamsExtensions
     {
         var builder = new ODataFilterExpressionBuilder<T>(queryParams.Filter, mapFields);
         return items.Where(builder.FilterLambda);
+    }
+
+    /// <summary>
+    /// Applies the ordering requested via <c>$orderby</c> to the query, using the same field mapping
+    /// convention as <see cref="ApplyODataFilters{T}"/>. Multiple order-by fields are applied in the
+    /// order they were supplied.
+    /// </summary>
+    public static IQueryable<T> ApplyODataOrderBy<T>(this IQueryable<T> items, ODataQueryParams queryParams, Action<ODataFieldMapping<T>> mapFields)
+    {
+        if (!queryParams.OrderBy.Any())
+            return items;
+
+        var fieldMapping = new ODataFieldMapping<T>();
+        mapFields(fieldMapping);
+
+        IOrderedQueryable<T>? ordered = null;
+        foreach (var option in queryParams.OrderBy)
+        {
+            var keySelector = fieldMapping.GetMapping(option.Field);
+            ordered = ordered is null
+                ? InvokeOrderMethod(items, keySelector, option.Direction == SortDirection.desc ? nameof(Queryable.OrderByDescending) : nameof(Queryable.OrderBy))
+                : InvokeOrderMethod(ordered, keySelector, option.Direction == SortDirection.desc ? nameof(Queryable.ThenByDescending) : nameof(Queryable.ThenBy));
+        }
+
+        return ordered!;
+    }
+
+    private static IOrderedQueryable<T> InvokeOrderMethod<T>(IQueryable<T> source, LambdaExpression keySelector, string methodName)
+    {
+        var method = typeof(Queryable).GetMethods()
+            .Single(m => m.Name == methodName && m.GetParameters().Length == 2)
+            .MakeGenericMethod(typeof(T), keySelector.ReturnType);
+
+        return (IOrderedQueryable<T>)method.Invoke(null, new object[] { source, keySelector })!;
     }
 }


### PR DESCRIPTION
Fixes #168

`GetSets` parsed the `$orderby` query parameter but never applied it, and `SheetMusicController.GetSetList` re-sorted results by `ArchiveNumber` afterwards, discarding any client-requested order.

`GetSets.Handler` now shares its field mapping (`archiveNumber`, `title`, `composer`, `arranger`, `soleSellingAgent`) between filtering and a new `ApplyODataOrderBy` extension, applying `$orderby` when supplied and falling back to `ArchiveNumber` ascending otherwise. The redundant re-sort in the controller was removed.

Added an integration test asserting `$orderby=title desc` returns results in descending title order.