### PR TITLE
feat: rate limit forgot-password and login endpoints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
         "gh": true,
         "git add": true,
         "git commit": true,
-        "git push": true
+        "git push": true,
+        "git checkout": true
     }
 }

--- a/src/SheetMusic.Api.Test/Tests/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/UserTests.cs
@@ -39,6 +39,33 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
+    public async Task V1_GetToken_ShouldReturn429_WhenRateLimitExceeded()
+    {
+        // Use a brand-new factory (own in-memory database and rate limiter state) with a low
+        // limit, so this test doesn't affect the shared factory/database used by other tests.
+        using var limitedFactory = new SheetMusicWebAppFactory().WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("RateLimiting:Token:PermitLimit", "2");
+            builder.UseSetting("RateLimiting:Token:WindowSeconds", "60");
+        });
+
+        var client = limitedFactory.CreateClient();
+
+        var collection = new List<KeyValuePair<string?, string?>>
+        {
+            new("grant_type", "basic"),
+            new("username", TestUser.Testesen.Email),
+            new("password", TestUser.Testesen.Password)
+        };
+
+        await client.PostAsync("token", new FormUrlEncodedContent(collection));
+        await client.PostAsync("token", new FormUrlEncodedContent(collection));
+        var response = await client.PostAsync("token", new FormUrlEncodedContent(collection));
+
+        response.StatusCode.Should().Be((HttpStatusCode)429);
+    }
+
+    [Fact]
     public async Task V1_GetToken_WithWrongPassword_ShouldReturnBadRequest()
     {
         var client = factory.CreateClient();
@@ -409,6 +436,27 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
         var response = await client.PostAsJsonAsync("users/forgot-password", new { Email = "not-an-email" });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_ShouldReturn429_WhenRateLimitExceeded()
+    {
+        // Use a brand-new factory (own in-memory database and rate limiter state) with a low
+        // limit, so this test doesn't affect the shared factory/database used by other tests.
+        using var limitedFactory = new SheetMusicWebAppFactory().WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("RateLimiting:ForgotPassword:PermitLimit", "2");
+            builder.UseSetting("RateLimiting:ForgotPassword:WindowSeconds", "60");
+        });
+
+        var client = limitedFactory.CreateClient();
+        client.DefaultRequestHeaders.Add("x-api-version", "2.0");
+
+        await client.PostAsJsonAsync("users/forgot-password", new { Email = "rate-limit-test@user.com" });
+        await client.PostAsJsonAsync("users/forgot-password", new { Email = "rate-limit-test@user.com" });
+        var response = await client.PostAsJsonAsync("users/forgot-password", new { Email = "rate-limit-test@user.com" });
+
+        response.StatusCode.Should().Be((HttpStatusCode)429);
     }
 
     [Fact]

--- a/src/SheetMusic.Api/Configuration/ConfigKeys.cs
+++ b/src/SheetMusic.Api/Configuration/ConfigKeys.cs
@@ -8,4 +8,8 @@ public static class ConfigKeys
     public const string ResendApiKey = "Resend:ApiKey";
     public const string EmailFromAddress = "Email:FromAddress";
     public const string EmailFrontendBaseUrl = "Email:FrontendBaseUrl";
+    public const string RateLimitingForgotPasswordPermitLimit = "RateLimiting:ForgotPassword:PermitLimit";
+    public const string RateLimitingForgotPasswordWindowSeconds = "RateLimiting:ForgotPassword:WindowSeconds";
+    public const string RateLimitingTokenPermitLimit = "RateLimiting:Token:PermitLimit";
+    public const string RateLimitingTokenWindowSeconds = "RateLimiting:Token:WindowSeconds";
 }

--- a/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
+++ b/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
@@ -1,7 +1,10 @@
 ﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading.RateLimiting;
 
 namespace SheetMusic.Api.Configuration;
 
@@ -163,4 +167,51 @@ public static class IServiceCollectionExtensions
 
         return services;
     }
+
+    public static IServiceCollection AddSheetMusicRateLimiting(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Azure App Service terminates client connections at its own front-end proxy, so the real client
+        // IP is only available via the X-Forwarded-For header rather than Connection.RemoteIpAddress.
+        services.Configure<ForwardedHeadersOptions>(options =>
+        {
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+            options.KnownIPNetworks.Clear();
+            options.KnownProxies.Clear();
+        });
+
+        var forgotPasswordPermitLimit = configuration.GetValue<int?>(ConfigKeys.RateLimitingForgotPasswordPermitLimit) ?? 10;
+        var forgotPasswordWindowSeconds = configuration.GetValue<int?>(ConfigKeys.RateLimitingForgotPasswordWindowSeconds) ?? 60;
+        var tokenPermitLimit = configuration.GetValue<int?>(ConfigKeys.RateLimitingTokenPermitLimit) ?? 20;
+        var tokenWindowSeconds = configuration.GetValue<int?>(ConfigKeys.RateLimitingTokenWindowSeconds) ?? 60;
+
+        services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+            options.AddPolicy(RateLimitPolicies.ForgotPassword, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: GetClientPartitionKey(httpContext),
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = forgotPasswordPermitLimit,
+                        Window = TimeSpan.FromSeconds(forgotPasswordWindowSeconds),
+                        QueueLimit = 0
+                    }));
+
+            options.AddPolicy(RateLimitPolicies.Token, httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: GetClientPartitionKey(httpContext),
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = tokenPermitLimit,
+                        Window = TimeSpan.FromSeconds(tokenWindowSeconds),
+                        QueueLimit = 0
+                    }));
+        });
+
+        return services;
+    }
+
+    private static string GetClientPartitionKey(HttpContext httpContext) =>
+        httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
 }

--- a/src/SheetMusic.Api/Configuration/RateLimitPolicies.cs
+++ b/src/SheetMusic.Api/Configuration/RateLimitPolicies.cs
@@ -1,0 +1,10 @@
+namespace SheetMusic.Api.Configuration;
+
+/// <summary>
+/// Named rate limiting policies applied to anonymous, resource-sensitive endpoints.
+/// </summary>
+public static class RateLimitPolicies
+{
+    public const string ForgotPassword = "forgot-password";
+    public const string Token = "token";
+}

--- a/src/SheetMusic.Api/Controllers/UsersController.cs
+++ b/src/SheetMusic.Api/Controllers/UsersController.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 using SheetMusic.Api.Authorization;
@@ -34,6 +35,7 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// Authenticate using Identity and receive a JWT token.
     /// </summary>
     [AllowAnonymous]
+    [EnableRateLimiting(RateLimitPolicies.Token)]
     [ProducesResponseType(typeof(ApiAccessTokens), (int)HttpStatusCode.OK)]
     [HttpPost("token")]
     public async Task<IActionResult> AuthenticateAsync([FromForm] LoginRequest request)
@@ -164,8 +166,10 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
 
     /// <summary>
     /// Request a password reset email. Always returns 200 to prevent user enumeration.
+    /// Rate limited per client IP to prevent abuse of the outbound email flow.
     /// </summary>
     [AllowAnonymous]
+    [EnableRateLimiting(RateLimitPolicies.ForgotPassword)]
     [HttpPost("users/forgot-password")]
     public async Task<IActionResult> ForgotPasswordAsync([FromBody] ForgotPasswordRequest request)
     {

--- a/src/SheetMusic.Api/Controllers/UsersV1Controller.cs
+++ b/src/SheetMusic.Api/Controllers/UsersV1Controller.cs
@@ -1,6 +1,7 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 using SheetMusic.Api.Authorization;
@@ -32,6 +33,7 @@ public class UsersV1Controller(IUserRepository userRepository, IConfiguration co
     /// Authenticate using legacy HMAC password hash and receive a JWT token.
     /// </summary>
     [AllowAnonymous]
+    [EnableRateLimiting(RateLimitPolicies.Token)]
     [ProducesResponseType(typeof(ApiAccessTokens), (int)HttpStatusCode.OK)]
     [HttpPost("token")]
     public async Task<IActionResult> AuthenticateAsync([FromForm] LoginRequest request)

--- a/src/SheetMusic.Api/Email/ResendEmailSender.cs
+++ b/src/SheetMusic.Api/Email/ResendEmailSender.cs
@@ -41,7 +41,7 @@ public class ResendEmailSender(IResend resend, IConfiguration configuration, ILo
             message.HtmlBody = BuildHtmlBody(displayName, resetUrl);
             message.TextBody = BuildTextBody(displayName, resetUrl);
 
-            await resend.EmailSendAsync(message);
+            await resend.EmailSendAsync(message, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/SheetMusic.Api/Program.cs
+++ b/src/SheetMusic.Api/Program.cs
@@ -54,6 +54,7 @@ builder.Services.Configure<FormOptions>(x =>
 builder.Services.AddSheetMusicSecurity(builder.Configuration);
 builder.Services.AddSheetMusicVersioning();
 builder.Services.AddSheetMusicSwagger();
+builder.Services.AddSheetMusicRateLimiting(builder.Configuration);
 
 builder.Services.AddSingleton<IBlobClient, BlobClient>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
@@ -84,11 +85,13 @@ if (!builder.Configuration.GetValue<bool>("SkipMigrations"))
 
 app.UseMiddleware<ErrorHandlerMiddleware>();
 
+app.UseForwardedHeaders();
 app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseHttpsRedirection();
 app.UseCors("AllowMember");
+app.UseRateLimiter();
 
 var provider = app.Services.GetRequiredService<IApiVersionDescriptionProvider>();
 

--- a/src/SheetMusic.Api/appsettings.json
+++ b/src/SheetMusic.Api/appsettings.json
@@ -11,5 +11,15 @@
   "AllowedHosts": "*",
   "Authentication": {
     "GoogleClientId": "41358703952-j9cs497p8p5cfi2kqfi24i58k4ge0nme.apps.googleusercontent.com"
+  },
+  "RateLimiting": {
+    "ForgotPassword": {
+      "PermitLimit": 10,
+      "WindowSeconds": 60
+    },
+    "Token": {
+      "PermitLimit": 20,
+      "WindowSeconds": 60
+    }
   }
 }


### PR DESCRIPTION
Fixes #156

Adds ASP.NET Core rate limiting to the auth endpoints that are most exposed to abuse:

- `POST /users/forgot-password` (`ForgotPassword` policy, configurable via `RateLimiting:ForgotPassword` in appsettings)
- `POST /users/token` on both v1 (`UsersV1Controller`) and v2 (`UsersController`) (`Token` policy, configurable via `RateLimiting:Token`)

Both policies use fixed-window limiters partitioned by client IP. Since the API runs behind Azure App Serviceʼs front-end proxy, `ForwardedHeadersOptions` is configured and `UseForwardedHeaders()` is registered as the first middleware so the real client IP (not the proxyʼs) is used for partitioning.

Also includes an unrelated small fix in `ResendEmailSender`: the cancellation token was not being passed through to `resend.EmailSendAsync`.

Added integration tests asserting both the forgot-password and token endpoints return 429 once the configured limit is exceeded.