### PR TITLE
fix: enforce account lockout after repeated failed login attempts

### DIFF
--- a/src/SheetMusic.Api.Test/Tests/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/UserTests.cs
@@ -490,4 +490,74 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    // --- Account lockout ---
+
+    private async Task<string> RegisterAndActivateUserAsync(HttpClient client, string password)
+    {
+        var email = $"lockout-{Guid.NewGuid():N}@user.com";
+
+        await client.PostAsJsonAsync("users/register", new
+        {
+            Id = Guid.NewGuid(),
+            Name = "Lockout Test User",
+            Email = email,
+            Password = password
+        });
+
+        // Activate the user directly through Identity (newly registered users are inactive)
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var appUser = await userManager.FindByEmailAsync(email);
+        appUser!.Inactive = false;
+        await userManager.UpdateAsync(appUser);
+
+        return email;
+    }
+
+    private static FormUrlEncodedContent BuildLoginForm(string email, string password) => new(new List<KeyValuePair<string?, string?>>
+    {
+        new("grant_type", "basic"),
+        new("username", email),
+        new("password", password)
+    });
+
+    [Fact]
+    public async Task V2_GetToken_ShouldLockAccount_AfterMaxFailedAttempts()
+    {
+        var client = CreateV2Client();
+        const string correctPassword = "SecurePassword123!";
+        var email = await RegisterAndActivateUserAsync(client, correctPassword);
+
+        // IdentityOptions.Lockout.MaxFailedAccessAttempts is configured to 5 in Program.cs
+        for (var i = 0; i < 5; i++)
+        {
+            var failedResponse = await client.PostAsync("token", BuildLoginForm(email, "wrong-password"));
+            failedResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        // Even with the correct password, the account should now be locked out.
+        // The response intentionally uses the same generic message as invalid credentials
+        // to avoid leaking lockout state to an unauthenticated caller.
+        var response = await client.PostAsync("token", BuildLoginForm(email, correctPassword));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_GetToken_ShouldNotLockAccount_BeforeMaxFailedAttemptsReached()
+    {
+        var client = CreateV2Client();
+        const string correctPassword = "SecurePassword123!";
+        var email = await RegisterAndActivateUserAsync(client, correctPassword);
+
+        for (var i = 0; i < 4; i++)
+        {
+            await client.PostAsync("token", BuildLoginForm(email, "wrong-password"));
+        }
+
+        var response = await client.PostAsync("token", BuildLoginForm(email, correctPassword));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
 }

--- a/src/SheetMusic.Api/Controllers/UsersController.cs
+++ b/src/SheetMusic.Api/Controllers/UsersController.cs
@@ -43,7 +43,11 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
         if (user == null || user.Inactive)
             return BadRequest(new { message = "Username or password is incorrect" });
 
-        var result = await signInManager.CheckPasswordSignInAsync(user, request.password, lockoutOnFailure: false);
+        // lockoutOnFailure: true increments the failed access count and locks the account after
+        // IdentityOptions.Lockout.MaxFailedAccessAttempts is reached. The response is intentionally
+        // identical to the generic invalid-credentials case to avoid leaking account lockout state
+        // to an unauthenticated caller.
+        var result = await signInManager.CheckPasswordSignInAsync(user, request.password, lockoutOnFailure: true);
 
         if (!result.Succeeded)
             return BadRequest(new { message = "Username or password is incorrect" });


### PR DESCRIPTION
## Summary

Account lockout was configured (`Lockout.MaxFailedAccessAttempts = 5`, `Lockout.DefaultLockoutTimeSpan = 15 min` in `Program.cs`) but never actually enforced: `UsersController.AuthenticateAsync` called `CheckPasswordSignInAsync(..., lockoutOnFailure: false)`, which disables lockout tracking entirely.

## Change

- Switched to `lockoutOnFailure: true` so failed attempts increment `AccessFailedCount` and lock the account once the threshold is reached.
- Reused the existing generic `"Username or password is incorrect"` response for the locked-out case (`SignInResult.Succeeded` is `false` when locked out), avoiding a distinct message that could leak account lockout state to an unauthenticated caller.
- Added integration tests: lockout is triggered after 5 failed attempts, and not triggered before the threshold.

## Related

- Part of #121 (Phase 4 user handling enhancements — account lockout policy task).

## Testing

- `dotnet test` — all 36 tests in `UserTests` pass, including the two new lockout tests.
