### PR TITLE
docs: describe domain-oriented folder layout in instructions and agents

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -16,6 +16,9 @@ You are a fast code reviewer specializing in the Sheet Music API codebase. Your 
 - ❌ Synchronous database operations (must be async)
 - ❌ Generic exceptions (must use ExceptionBase subclasses)
 - ❌ Commands and Queries mixed in same class
+- ❌ New files added to legacy artifact-type folders (`Controllers/`, `CQRS/`, `Repositories/`, `Database/Entities/`) instead of the domain folder (`Projects/`, `Sets/`, `Parts/`, `Users/`)
+- ❌ Namespace does not match the domain folder (`SheetMusic.Api.{Domain}[.Commands|.Queries|...]`)
+- ❌ Domain-specific types placed in `Shared/`, or shared infrastructure buried inside a domain
 
 ### Code Style Issues
 - ❌ Not using primary constructors for DI

--- a/.github/agents/migration-helper.agent.md
+++ b/.github/agents/migration-helper.agent.md
@@ -18,9 +18,17 @@ You are an Entity Framework Core migration specialist for the Sheet Music API. Y
 
 - **EF Core Migrations**: Creating, reviewing, applying, reverting
 - **SQL Server**: Understanding generated SQL and potential issues
-- **Database entities**: SheetMusicContext and all entities in `Database/Entities/`
+- **Database entities**: `SheetMusicContext` and domain entities in `{Domain}/Entities/` (`Projects/`, `Sets/`, `Parts/`, `Users/`)
 - **Data seeding**: Adding initial or test data
 - **Migration safety**: Detecting breaking changes, data loss risks
+
+## Folder Layout
+
+- Source is organized by domain, not artifact type
+- Entities live in `{Domain}/Entities/`; `SheetMusicContext` and `DatabaseSeeder` live in `Shared/Database/`
+- Migrations are **not** split per domain - they stay in a single ordered folder: `Shared/Database/Migrations`
+- A refactor to this layout is in progress (issue #192); some entities may still be in `Database/Entities/`
+- Moving an entity between folders/namespaces must **not** produce a migration - if `dotnet ef migrations add` generates operations after a move, the table/column mapping changed and must be fixed
 
 ## Entity Conventions
 
@@ -36,7 +44,7 @@ You are an Entity Framework Core migration specialist for the Sheet Music API. Y
 1. **Review entity changes**: Read modified entity files to understand the change
 2. **Validate relationships**: Ensure navigation properties are bidirectional
 3. **Generate migration**: Run `dotnet ef migrations add {DescriptiveName} --project src/SheetMusic.Api`
-4. **Review generated code**: Check `Migrations/` folder for Up/Down methods
+4. **Review generated code**: Check `Shared/Database/Migrations/` for Up/Down methods
 5. **Validate SQL**: Look for potential data loss, breaking changes, or missing indexes
 6. **Document**: Note any manual steps required (data migration, cleanup)
 
@@ -58,7 +66,7 @@ You are an Entity Framework Core migration specialist for the Sheet Music API. Y
 
 1. **List applied**: `dotnet ef migrations list --project src/SheetMusic.Api`
 2. **Revert**: `dotnet ef database update {PreviousMigrationName} --project src/SheetMusic.Api`
-3. **Remove migration file**: Delete from `Migrations/` folder
+3. **Remove migration file**: Delete from `Shared/Database/Migrations/` folder
 4. **Rebuild**: `dotnet build`
 
 ## Migration Naming

--- a/.github/agents/sheetmusic-dev.agent.md
+++ b/.github/agents/sheetmusic-dev.agent.md
@@ -30,6 +30,15 @@ You are an expert developer specializing in the Sheet Music API codebase. Your r
 
 ## Architectural Rules
 
+### Domain-oriented folders (vertical slices)
+- Source is organized by **domain**, not artifact type: `Projects/`, `Sets/`, `Parts/`, `Users/`, plus `Shared/` for cross-cutting infrastructure
+- Each domain owns `{Domain}/{Entity}Controller.cs`, `{Domain}/Commands/`, `{Domain}/Queries/`, `{Domain}/RequestModels/`, `{Domain}/ViewModels/`, `{Domain}/Entities/`, `{Domain}/Errors/`
+- Namespaces follow folders: `SheetMusic.Api.Projects.Commands`, `SheetMusic.Api.Users.Entities`, etc.
+- Put something in `Shared/` only if more than one domain uses it
+- EF Core migrations stay in one ordered folder: `Shared/Database/Migrations`
+- Tests mirror the layout: `SheetMusic.Api.Test/Tests/{Domain}/`
+- Migration in progress (issue #192): some files may still sit in the legacy `Controllers/`, `CQRS/`, `Database/Entities/`, `Repositories/` folders. Place new code in the domain layout; do not opportunistically move legacy files unless asked
+
 ### Controllers
 - Delegate ONLY to MediatR - no business logic
 - Primary constructor with `IMediator mediator`
@@ -38,16 +47,16 @@ You are an expert developer specializing in the Sheet Music API codebase. Your r
 - Return `ActionResult<T>` with ViewModels (never entities directly)
 
 ### CQRS
-- Commands in `CQRS/Command/`, Queries in `CQRS/Query/`
+- Commands in `{Domain}/Commands/`, Queries in `{Domain}/Queries/`
 - Verb-first naming: `AddPart`, `UpdateSetMetadata`, `DeleteProject`
 - Queries: `Get{Entity}Collection`, `Get{Entity}`
 - Handler as nested class implementing `IRequestHandler<TRequest, TResponse>`
 - Inject `SheetMusicContext db` via primary constructor
 
 ### Models
-- RequestModels in `Controllers/RequestModels/` with nested `Validator` class
-- ViewModels in `Controllers/ViewModels/` prefixed with `Api{Entity}`
-- Entities in `Database/Entities/`
+- RequestModels in `{Domain}/RequestModels/` with nested `Validator` class
+- ViewModels in `{Domain}/ViewModels/` prefixed with `Api{Entity}`
+- Entities in `{Domain}/Entities/`
 
 ### Error Handling
 - Create specific exception types inheriting `ExceptionBase`
@@ -66,21 +75,22 @@ You are an expert developer specializing in the Sheet Music API codebase. Your r
 When adding a new endpoint:
 
 1. **Analyze**: Review existing similar endpoints to understand patterns
-2. **Create Command/Query**: In appropriate CQRS folder with nested Handler
-3. **Create/Update RequestModel**: With nested Validator using FluentValidation
-4. **Create/Update ViewModel**: Api-prefixed in ViewModels folder
-5. **Add Controller Method**: With XML docs, proper attributes, delegate to MediatR
-6. **Add Tests (mandatory, not optional)**: Integration tests for happy path and authorization
-7. **Review**: Invoke Code Reviewer subagent to validate against patterns
+2. **Identify the domain**: Decide which of `Projects/`, `Sets/`, `Parts/`, `Users/` owns the feature
+3. **Create Command/Query**: In `{Domain}/Commands/` or `{Domain}/Queries/` with nested Handler
+4. **Create/Update RequestModel**: In `{Domain}/RequestModels/` with nested Validator using FluentValidation
+5. **Create/Update ViewModel**: Api-prefixed in `{Domain}/ViewModels/`
+6. **Add Controller Method**: With XML docs, proper attributes, delegate to MediatR
+7. **Add Tests (mandatory, not optional)**: Integration tests for happy path and authorization, in `Tests/{Domain}/`
+8. **Review**: Invoke Code Reviewer subagent to validate against patterns
 
 When adding a new entity:
 
-1. **Create Entity**: In `Database/Entities/` with Guid Id and navigation properties
+1. **Create Entity**: In `{Domain}/Entities/` with Guid Id and navigation properties
 2. **Add DbSet**: To `SheetMusicContext`
-3. **Create Migration**: Run `dotnet ef migrations add {Name}`
-4. **Create ViewModel and RequestModel**
-5. **Create CRUD Commands/Queries**
-6. **Create Controller**
+3. **Create Migration**: Run `dotnet ef migrations add {Name}` (lands in `Shared/Database/Migrations`)
+4. **Create ViewModel and RequestModel** in the same domain
+5. **Create CRUD Commands/Queries** in the same domain
+6. **Create Controller** in the domain folder
 7. **Add Tests (mandatory, not optional)**
 8. **Review**: Invoke Code Reviewer subagent to validate implementation
 
@@ -103,6 +113,8 @@ When changing existing behavior (bug fix, field addition, small tweak) outside t
 - DO NOT skip validation
 - DO NOT create generic exceptions
 - DO NOT skip or merely suggest tests - implement them as part of the change
+- DO NOT add new files to the legacy artifact-type folders (`Controllers/`, `CQRS/`, `Repositories/`, `Database/Entities/`)
+- DO NOT place domain-specific types in `Shared/`
 
 ## Quality Assurance
 

--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -9,6 +9,16 @@ ASP.NET Core 8.0 Web API for managing sheet music collections. Uses CQRS, Mediat
 
 ## Architecture
 
+### Domain-oriented folders (vertical slices)
+- Source is organized by **domain**, not by artifact type
+- Each domain owns its controller, commands, queries, request models, view models, entities and errors
+- Domains: `Projects/`, `Sets/`, `Parts/`, `Users/`, plus `Shared/` for cross-cutting infrastructure
+- Namespaces follow folders: `SheetMusic.Api.Projects.Commands`, `SheetMusic.Api.Users.Entities`, etc.
+- Put a type in `Shared/` only if more than one domain uses it; otherwise it belongs in the owning domain
+- Avoid new domain-to-domain dependencies (existing `Sets` <-> `Parts` coupling is accepted)
+
+> Migration in progress: tracked by issue #192. Some folders may still use the legacy artifact-type layout (`Controllers/`, `CQRS/`, `Database/Entities/`, `Repositories/`). New code goes in the domain layout; when touching legacy files, follow the layout that file currently lives in unless the move is part of the tracked refactor.
+
 ### CQRS with MediatR
 - All business logic uses CQRS pattern with MediatR
 - Commands modify state (e.g., `AddPart`, `UpdateSetMetadata`)
@@ -34,11 +44,11 @@ ASP.NET Core 8.0 Web API for managing sheet music collections. Uses CQRS, Mediat
 - `LangVersion` latest
 
 ### Naming
-- Controllers: `{Entity}Controller`
-- Request models: `{Entity}Request` (in `Controllers/RequestModels/`)
-- View models: `Api{Entity}` (in `Controllers/ViewModels/`)
-- Commands: Verb-first (e.g., `AddPart`, `DeleteSet`)
-- Queries: `Get{Entity}` (e.g., `GetPartCollection`)
+- Controllers: `{Entity}Controller` (in `{Domain}/`)
+- Request models: `{Entity}Request` (in `{Domain}/RequestModels/`)
+- View models: `Api{Entity}` (in `{Domain}/ViewModels/`)
+- Commands: Verb-first (e.g., `AddPart`, `DeleteSet`) in `{Domain}/Commands/`
+- Queries: `Get{Entity}` (e.g., `GetPartCollection`) in `{Domain}/Queries/`
 
 ### Controllers
 - Mark with `[ApiController]`, `[Produces("application/json")]`
@@ -65,16 +75,31 @@ ASP.NET Core 8.0 Web API for managing sheet music collections. Uses CQRS, Mediat
 ## File Organization
 ```
 SheetMusic.Api/
-├── Controllers/          # API controllers
-│   ├── RequestModels/   # Input DTOs + Validators
-│   └── ViewModels/      # Output DTOs (Api-prefixed)
-├── CQRS/
-│   ├── Command/         # State-changing operations
-│   └── Query/           # Read operations
-├── Database/Entities/   # EF Core entities
-├── Errors/              # Custom exceptions
-└── Repositories/        # Data access
+├── Projects/                # Project, ProjectSheetMusicSet
+│   ├── ProjectsController.cs
+│   ├── Commands/            # State-changing operations
+│   ├── Queries/             # Read operations
+│   ├── RequestModels/       # Input DTOs + nested Validators
+│   ├── ViewModels/          # Output DTOs (Api-prefixed)
+│   ├── Entities/            # EF Core entities owned by the domain
+│   └── Errors/              # Domain-specific exceptions
+├── Sets/                    # SheetMusicSet, SheetMusicPart, Category
+├── Parts/                   # MusicPart, MusicPartAlias, part search index
+├── Users/                   # ApplicationUser, RefreshToken, Musician, Authorization/
+└── Shared/                  # Cross-cutting infrastructure only
+    ├── Database/            # SheetMusicContext, DatabaseSeeder, Migrations
+    ├── Errors/              # ExceptionBase, ErrorHandlerMiddleware, generic errors
+    ├── BlobStorage/
+    ├── Search/              # Index infrastructure
+    ├── Email/
+    ├── OData/
+    ├── Configuration/
+    └── Utilities/
 ```
+
+Tests mirror the domain layout: `SheetMusic.Api.Test/Tests/{Domain}/`.
+
+EF Core migrations are **not** split per domain - they stay in a single ordered folder under `Shared/Database/Migrations`.
 
 ## Key Principles
 - Controllers delegate to MediatR only

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "window.title": "${activeRepositoryBranchName}",
     "chat.tools.terminal.autoApprove": {
         "dotnet test": true,
         "dotnet add": true,


### PR DESCRIPTION
Documents the target **domain (vertical slice)** folder layout in the Copilot instructions and agent files, ahead of the refactor tracked by #192.

## Changes

- **`.github/instructions/copilot-instructions.md`**
  - New "Domain-oriented folders (vertical slices)" architecture section
  - Naming section now points at `{Domain}/Commands/`, `{Domain}/Queries/`, `{Domain}/RequestModels/`, `{Domain}/ViewModels/`
  - File Organization tree replaced with the domain layout (`Projects/`, `Sets/`, `Parts/`, `Users/`, `Shared/`)
  - Notes that tests mirror the layout and that migrations stay in a single ordered folder
- **`.github/agents/sheetmusic-dev.agent.md`**
  - Domain-slice rules, updated CQRS/Models paths
  - Endpoint/entity workflows now start with "identify the domain"
  - New constraints: no new files in legacy artifact-type folders, no domain-specific types in `Shared/`
- **`.github/agents/code-reviewer.agent.md`**
  - New architecture checks for folder placement, namespace/folder mismatch, and `Shared/` misuse
- **`.github/agents/migration-helper.agent.md`**
  - Folder layout section, migrations path updated to `Shared/Database/Migrations`
  - Adds the rule that moving an entity between namespaces must not generate a migration
- **`.vscode/settings.json`**
  - Set `window.title` to the active repository branch name

All docs note that the refactor is in progress (#192) so agents handle the mixed state correctly.

## Notes

Documentation only - no source or behavior changes.

Related to #192
