### PR TITLE
fix(sets): return 400 instead of bare 500 for invalid OData query params

### DIFF
--- a/src/SheetMusic.Api.Test/Infrastructure/Authentication/IntgTestAuthenticationHandler.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/Authentication/IntgTestAuthenticationHandler.cs
@@ -17,10 +17,20 @@ internal class IntgTestAuthenticationHandler(IOptionsMonitor<IntgTestSchemeOptio
     {
         try
         {
-            var claims = GatherTestUserClaims();
+            var testUser = ResolveTestUser();
+
+            if (testUser is null)
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.Name, testUser.Identifier.ToString()),
+                new(ClaimTypes.Email, testUser.Email ?? "")
+            };
+
             var testIdentity = new ClaimsIdentity(claims, AuthenticationScheme);
-            var testUser = new ClaimsPrincipal(testIdentity);
-            var ticket = new AuthenticationTicket(testUser, new AuthenticationProperties(), AuthenticationScheme);
+            var principal = new ClaimsPrincipal(testIdentity);
+            var ticket = new AuthenticationTicket(principal, new AuthenticationProperties(), AuthenticationScheme);
 
             return Task.FromResult(AuthenticateResult.Success(ticket));
         }
@@ -30,25 +40,12 @@ internal class IntgTestAuthenticationHandler(IOptionsMonitor<IntgTestSchemeOptio
         }
     }
 
-    private List<Claim> GatherTestUserClaims()
+    private TestUser? ResolveTestUser()
     {
-        TestUser? testUser;
-
         try
         {
-            var token = Request.Headers["Authorization"].ToString();
-            testUser = AuthTokenUtilities.UnwrapAuthToken<TestUser>(token);
-
-            if (testUser is null)
-                return new List<Claim>();
-
-            var claims = new List<Claim>
-            {
-                new Claim(ClaimTypes.Name, testUser.Identifier.ToString()),
-                new Claim(ClaimTypes.Email, testUser.Email ?? "")
-            };
-
-            return claims;
+            var token = Request.Headers.Authorization.ToString();
+            return AuthTokenUtilities.UnwrapAuthToken<TestUser>(token);
         }
         catch (Exception ex)
         {

--- a/src/SheetMusic.Api.Test/Infrastructure/TestCollections/Collections.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/TestCollections/Collections.cs
@@ -5,5 +5,6 @@ public class Collections
     public const string Project = "Project";
     public const string User = "Users";
     public const string Set = "Sets";
+    public const string SetList = "SetList";
     public const string Part = "Parts";
 }

--- a/src/SheetMusic.Api.Test/Infrastructure/TestCollections/SetListCollection.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/TestCollections/SetListCollection.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace SheetMusic.Api.Test.Infrastructure.TestCollections;
+
+/// <summary>
+/// Dedicated collection for <c>GET /sheetmusic/sets</c> tests. Having its own collection gives the
+/// tests an isolated in-memory database, so result counts and ordering are not affected by sets
+/// created by other test classes.
+/// </summary>
+[CollectionDefinition(Collections.SetList)]
+public class SetListCollection : ICollectionFixture<SheetMusicWebAppFactory>
+{
+    //only for marking collections
+}

--- a/src/SheetMusic.Api.Test/Sets/GetSetListTests.cs
+++ b/src/SheetMusic.Api.Test/Sets/GetSetListTests.cs
@@ -1,0 +1,864 @@
+using FluentAssertions;
+using SheetMusic.Api.Test.Infrastructure;
+using SheetMusic.Api.Test.Infrastructure.Authentication;
+using SheetMusic.Api.Test.Infrastructure.TestCollections;
+using SheetMusic.Api.Test.Models;
+using SheetMusic.Api.Test.Utility;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SheetMusic.Api.Test.Sets;
+
+/// <summary>
+/// Full coverage of <c>GET /sheetmusic/sets</c>. Runs in its own collection so the in-memory
+/// database is isolated from other test classes.
+/// </summary>
+[Collection(Collections.SetList)]
+public class GetSetListTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusicWebAppFactory>
+{
+    private const string Marker = "SetListCorpus";
+
+    private static readonly SemaphoreSlim CorpusLock = new(1, 1);
+    private static List<ApiSet>? corpus;
+
+    /// <summary>
+    /// Insertion order deliberately differs from alphabetical title order, so ordering tests
+    /// cannot pass by accident on the default archive number ordering.
+    /// </summary>
+    private static readonly CorpusSpec[] CorpusSpecs =
+    [
+        new("Hotel", 2, 1, 1),
+        new("Charlie", 1, 3, 2),
+        new("Alfa", 3, 2, 1),
+        new("Golf", 1, 1, 3),
+        new("Delta", 2, 3, 2),
+        new("Foxtrot", 3, 2, 3),
+        new("Bravo", 1, 1, 1),
+        new("Echo", 2, 3, 2)
+    ];
+
+    #region Baseline
+
+    [Fact]
+    public async Task GetSetList_ShouldReturnAllSetsOrderedByArchiveNumberAscending_WhenNoQueryParams()
+    {
+        var seeded = await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, "");
+
+        items.Should().BeInAscendingOrder(s => s.ArchiveNumber);
+
+        foreach (var set in seeded)
+            items.Should().Contain(s => s.Id == set.Id && s.Title == set.Title);
+    }
+
+    [Fact]
+    public async Task GetSetList_ShouldReturnEmptyArray_WhenDatabaseIsEmpty()
+    {
+        using var emptyFactory = new SheetMusicWebAppFactory();
+        var client = emptyFactory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, "");
+
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSetList_ShouldReturn401_WhenUnauthenticated()
+    {
+        var client = factory.CreateClient();
+
+        var response = await client.GetAsync("sheetmusic/sets");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetSetList_ShouldPopulateZipDownloadUrlAndPartsUrl()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Search(Marker));
+
+        items.Should().NotBeEmpty();
+
+        foreach (var item in items)
+        {
+            Uri.IsWellFormedUriString(item.ZipDownloadUrl, UriKind.Absolute).Should().BeTrue();
+            Uri.IsWellFormedUriString(item.PartsUrl, UriKind.Absolute).Should().BeTrue();
+            item.ZipDownloadUrl.Should().EndWith($"/sheetmusic/sets/{item.Id}/zip");
+            item.PartsUrl.Should().EndWith($"/sheetmusic/sets/{item.Id}/parts");
+        }
+    }
+
+    [Theory]
+    [InlineData("1.0")]
+    [InlineData("2.0")]
+    public async Task GetSetList_ShouldBeSuccessful_ForEveryApiVersion(string apiVersion)
+    {
+        var seeded = await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, $"{Search(Marker)}&api-version={apiVersion}");
+
+        items.Should().HaveCount(seeded.Count);
+    }
+
+    #endregion
+
+    #region $search
+
+    [Fact]
+    public async Task GetSetList_WithSearchOnTitle_ShouldReturnMatchingSet()
+    {
+        var seeded = await GetCorpusAsync();
+        var alfa = CorpusSet(seeded, "Alfa");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Search(alfa.Title!));
+
+        items.Should().ContainSingle();
+        items[0].Id.Should().Be(alfa.Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithSearchOnComposer_ShouldReturnMatchingSets()
+    {
+        var seeded = await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Search(Composer(3)));
+
+        items.Select(i => i.Title).Should().BeEquivalentTo([TitleOf("Alfa"), TitleOf("Foxtrot")]);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithSearchOnArranger_ShouldReturnMatchingSets()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Search(Arranger(2)));
+
+        items.Select(i => i.Title).Should().BeEquivalentTo([TitleOf("Alfa"), TitleOf("Foxtrot")]);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithSearchOnArchiveNumber_ShouldReturnMatchingSet()
+    {
+        var seeded = await GetCorpusAsync();
+        var echo = CorpusSet(seeded, "Echo");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Search(echo.ArchiveNumber.ToString()));
+
+        items.Should().Contain(s => s.Id == echo.Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithSearchWithoutMatches_ShouldReturnEmptyArray()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Search("no-set-will-ever-match-this-term"));
+
+        items.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetSetList_WithBlankSearch_ShouldBeTreatedAsNoSearch(string term)
+    {
+        var seeded = await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Search(term));
+
+        foreach (var set in seeded)
+            items.Should().Contain(s => s.Id == set.Id);
+    }
+
+    [Theory]
+    [InlineData("%'\"()[]*?<>&#\\/;:=+")]
+    [InlineData("Ærlig Øst Åse")]
+    public async Task GetSetList_WithSpecialCharactersInSearch_ShouldNotThrow(string term)
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var response = await client.GetAsync($"sheetmusic/sets{Search(term)}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithVeryLongSearchTerm_ShouldNotThrow()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var response = await client.GetAsync($"sheetmusic/sets{Search(new string('a', 2000))}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    #endregion
+
+    #region $filter
+
+    [Fact]
+    public async Task GetSetList_WithFilterEqOnArchiveNumber_ShouldReturnMatchingSet()
+    {
+        var seeded = await GetCorpusAsync();
+        var delta = CorpusSet(seeded, "Delta");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"archiveNumber eq {delta.ArchiveNumber}"));
+
+        items.Should().ContainSingle();
+        items[0].Id.Should().Be(delta.Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithFilterEqOnTitle_ShouldReturnMatchingSet()
+    {
+        var seeded = await GetCorpusAsync();
+        var golf = CorpusSet(seeded, "Golf");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"title eq '{golf.Title}'"));
+
+        items.Should().ContainSingle();
+        items[0].Id.Should().Be(golf.Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithFilterEqOnComposer_ShouldReturnMatchingSets()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"composer eq '{Composer(1)}'"));
+
+        items.Select(i => i.Title).Should().BeEquivalentTo([TitleOf("Charlie"), TitleOf("Golf"), TitleOf("Bravo")]);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithFilterEqOnArranger_ShouldReturnMatchingSets()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"arranger eq '{Arranger(2)}'"));
+
+        items.Select(i => i.Title).Should().BeEquivalentTo([TitleOf("Alfa"), TitleOf("Foxtrot")]);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithFilterEqOnSoleSellingAgent_ShouldReturnMatchingSets()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"soleSellingAgent eq '{Agent(3)}'"));
+
+        items.Select(i => i.Title).Should().BeEquivalentTo([TitleOf("Golf"), TitleOf("Foxtrot")]);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithFilterNeOnArchiveNumber_ShouldExcludeMatchingSet()
+    {
+        var seeded = await GetCorpusAsync();
+        var hotel = CorpusSet(seeded, "Hotel");
+        var charlie = CorpusSet(seeded, "Charlie");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"archiveNumber ne {hotel.ArchiveNumber}"));
+
+        items.Should().NotContain(s => s.Id == hotel.Id);
+        items.Should().Contain(s => s.Id == charlie.Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithFilterGtOnArchiveNumber_ShouldReturnHigherNumbersOnly()
+    {
+        var seeded = await GetCorpusAsync();
+        var alfa = CorpusSet(seeded, "Alfa");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"archiveNumber gt {alfa.ArchiveNumber}"));
+
+        items.Should().OnlyContain(s => s.ArchiveNumber > alfa.ArchiveNumber);
+        items.Should().Contain(s => s.Id == CorpusSet(seeded, "Golf").Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithFilterLtOnArchiveNumber_ShouldReturnLowerNumbersOnly()
+    {
+        var seeded = await GetCorpusAsync();
+        var echo = CorpusSet(seeded, "Echo");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"archiveNumber lt {echo.ArchiveNumber}"));
+
+        items.Should().OnlyContain(s => s.ArchiveNumber < echo.ArchiveNumber);
+        items.Should().Contain(s => s.Id == CorpusSet(seeded, "Hotel").Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithFilterGeOnArchiveNumber_ShouldIncludeBoundary()
+    {
+        var seeded = await GetCorpusAsync();
+        var alfa = CorpusSet(seeded, "Alfa");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"archiveNumber ge {alfa.ArchiveNumber}"));
+
+        items.Should().OnlyContain(s => s.ArchiveNumber >= alfa.ArchiveNumber);
+        items.Should().Contain(s => s.Id == alfa.Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithFilterLeOnArchiveNumber_ShouldIncludeBoundary()
+    {
+        var seeded = await GetCorpusAsync();
+        var echo = CorpusSet(seeded, "Echo");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"archiveNumber le {echo.ArchiveNumber}"));
+
+        items.Should().OnlyContain(s => s.ArchiveNumber <= echo.ArchiveNumber);
+        items.Should().Contain(s => s.Id == echo.Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithAndFilterGroup_ShouldReturnIntersection()
+    {
+        var seeded = await GetCorpusAsync();
+        var alfa = CorpusSet(seeded, "Alfa");
+        var delta = CorpusSet(seeded, "Delta");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"archiveNumber ge {alfa.ArchiveNumber} and archiveNumber le {delta.ArchiveNumber}"));
+
+        items.Should().OnlyContain(s => s.ArchiveNumber >= alfa.ArchiveNumber && s.ArchiveNumber <= delta.ArchiveNumber);
+        items.Should().Contain(s => s.Id == alfa.Id);
+        items.Should().Contain(s => s.Id == delta.Id);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithOrFilterGroup_ShouldReturnUnion()
+    {
+        var seeded = await GetCorpusAsync();
+        var bravo = CorpusSet(seeded, "Bravo");
+        var echo = CorpusSet(seeded, "Echo");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"title eq '{bravo.Title}' or title eq '{echo.Title}'"));
+
+        items.Select(i => i.Id).Should().BeEquivalentTo([bravo.Id, echo.Id]);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithInFilter_ShouldReturnAllListedValues()
+    {
+        var seeded = await GetCorpusAsync();
+        var charlie = CorpusSet(seeded, "Charlie");
+        var foxtrot = CorpusSet(seeded, "Foxtrot");
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Filter($"title in ('{charlie.Title}','{foxtrot.Title}')"));
+
+        items.Select(i => i.Id).Should().BeEquivalentTo([charlie.Id, foxtrot.Id]);
+    }
+
+    [Theory]
+    [InlineData("foo eq 'bar'")]
+    [InlineData("title")]
+    [InlineData("title eq")]
+    [InlineData("title like 'something'")]
+    [InlineData("archiveNumber eq 'notanumber'")]
+    [InlineData("(((")]
+    public async Task GetSetList_WithInvalidFilter_ShouldReturnBadRequestWithProblemDetails(string filter)
+    {
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        await AssertBadRequestAsync(client, Filter(filter));
+    }
+
+    [Fact]
+    public async Task GetSetList_WithEmptyFilter_ShouldReturnBadRequestWithProblemDetails()
+    {
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        await AssertBadRequestAsync(client, "?$filter=");
+    }
+
+    #endregion
+
+    #region $orderby
+
+    [Theory]
+    [InlineData("title")]
+    [InlineData("composer")]
+    [InlineData("arranger")]
+    [InlineData("soleSellingAgent")]
+    [InlineData("archiveNumber")]
+    public async Task GetSetList_WithOrderByAscending_ShouldReturnSetsInAscendingOrder(string field)
+    {
+        var seeded = await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, $"{Search(Marker)}&$orderby={field} asc");
+
+        items.Should().HaveCount(seeded.Count);
+        items.Select(i => SortKey(i, field)).Should().BeInAscendingOrder(StringComparer.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("title")]
+    [InlineData("composer")]
+    [InlineData("arranger")]
+    [InlineData("soleSellingAgent")]
+    [InlineData("archiveNumber")]
+    public async Task GetSetList_WithOrderByDescending_ShouldReturnSetsInDescendingOrder(string field)
+    {
+        var seeded = await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, $"{Search(Marker)}&$orderby={field} desc");
+
+        items.Should().HaveCount(seeded.Count);
+        items.Select(i => SortKey(i, field)).Should().BeInDescendingOrder(StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithOrderByWithoutDirection_ShouldSortAscending()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, $"{Search(Marker)}&$orderby=title");
+
+        items.Select(i => i.Title).Should().BeInAscendingOrder(StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithMultipleOrderByClauses_ShouldApplyThemInSequence()
+    {
+        var seeded = await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, $"{Search(Marker)}&$orderby=composer asc,title desc");
+
+        var expected = seeded
+            .OrderBy(s => s.Composer, StringComparer.Ordinal)
+            .ThenByDescending(s => s.Title, StringComparer.Ordinal)
+            .Select(s => s.Title)
+            .ToList();
+
+        items.Select(i => i.Title).Should().ContainInOrder(expected);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithoutOrderBy_ShouldUseArchiveNumberAscendingAsDefault()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Search(Marker));
+
+        items.Should().BeInAscendingOrder(s => s.ArchiveNumber);
+    }
+
+    [Theory]
+    [InlineData("$orderby=foo")]
+    [InlineData("$orderby=title sideways")]
+    [InlineData("$orderby=title asc extra")]
+    [InlineData("$orderby=")]
+    public async Task GetSetList_WithInvalidOrderBy_ShouldReturnBadRequestWithProblemDetails(string clause)
+    {
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        await AssertBadRequestAsync(client, $"?{clause}");
+    }
+
+    #endregion
+
+    #region $top and $skip
+
+    [Fact]
+    public async Task GetSetList_WithTop_ShouldLimitResultCount()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, $"{Search(Marker)}&$top=3");
+
+        items.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithSkip_ShouldOffsetResults()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var all = await GetSetsAsync(client, Search(Marker));
+        var skipped = await GetSetsAsync(client, $"{Search(Marker)}&$skip=2");
+
+        skipped.Select(s => s.Id).Should().Equal(all.Skip(2).Select(s => s.Id));
+    }
+
+    [Fact]
+    public async Task GetSetList_WithTopAndSkip_ShouldPageCorrectly()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var all = await GetSetsAsync(client, Search(Marker));
+        var page = await GetSetsAsync(client, $"{Search(Marker)}&$skip=2&$top=3");
+
+        page.Select(s => s.Id).Should().Equal(all.Skip(2).Take(3).Select(s => s.Id));
+    }
+
+    [Fact]
+    public async Task GetSetList_WithSkipBeyondResultCount_ShouldReturnEmptyArray()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, $"{Search(Marker)}&$skip=100000");
+
+        items.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("$top=0")]
+    [InlineData("$top=-1")]
+    [InlineData("$top=notanumber")]
+    [InlineData("$top=")]
+    [InlineData("$skip=-1")]
+    [InlineData("$skip=notanumber")]
+    [InlineData("$skip=")]
+    public async Task GetSetList_WithInvalidPaging_ShouldReturnBadRequestWithProblemDetails(string clause)
+    {
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        await AssertBadRequestAsync(client, $"?{clause}");
+    }
+
+    #endregion
+
+    #region $expand
+
+    [Fact]
+    public async Task GetSetList_WithExpandParts_ShouldIncludePartsWithDownloadUrls()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var title = $"ExpandTest-{Guid.NewGuid()}";
+        var set = await CreateSetAsync(adminClient, title);
+        var part = await new PartDataBuilder(adminClient).ProvisionSinglePartAsync();
+        await AddPartToSetAsync(adminClient, set, part.Name);
+
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+        var items = await GetSetsAsync(client, $"{Search(title)}&$expand=parts");
+
+        items.Should().ContainSingle();
+        items[0].Parts.Should().NotBeNull();
+        items[0].Parts.Should().ContainSingle();
+
+        var setPart = items[0].Parts![0];
+        setPart.PdfDownloadUrl.Should().EndWith($"/sheetmusic/sets/{set.Id}/parts/{setPart.MusicPartId}/pdf");
+        setPart.DeletePartUrl.Should().EndWith($"/sheetmusic/sets/{set.Id}/parts/{setPart.MusicPartId}");
+    }
+
+    [Fact]
+    public async Task GetSetList_WithoutExpand_ShouldLeavePartsNull()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, Search(Marker));
+
+        items.Should().OnlyContain(s => s.Parts == null);
+    }
+
+    [Theory]
+    [InlineData("$expand=categories")]
+    [InlineData("$expand=parts,unknown")]
+    [InlineData("$expand=parts,")]
+    [InlineData("$expand=")]
+    public async Task GetSetList_WithInvalidExpand_ShouldReturnBadRequestWithProblemDetails(string clause)
+    {
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        await AssertBadRequestAsync(client, $"?{clause}");
+    }
+
+    #endregion
+
+    #region category
+
+    [Fact]
+    public async Task GetSetList_FilteredByCategoryName_ShouldReturnOnlyMatchingSets()
+    {
+        var seeded = await GetCorpusAsync();
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var alfa = CorpusSet(seeded, "Alfa");
+        var bravo = CorpusSet(seeded, "Bravo");
+        var category = await CreateCategoryAsync(adminClient);
+
+        await AssignCategoryAsync(adminClient, alfa, category);
+        await AssignCategoryAsync(adminClient, bravo, category);
+
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+        var items = await GetSetsAsync(client, $"?category={Uri.EscapeDataString(category.Name!)}");
+
+        items.Select(i => i.Id).Should().BeEquivalentTo([alfa.Id, bravo.Id]);
+    }
+
+    [Fact]
+    public async Task GetSetList_FilteredByCategoryId_ShouldReturnOnlyMatchingSets()
+    {
+        var seeded = await GetCorpusAsync();
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var delta = CorpusSet(seeded, "Delta");
+        var category = await CreateCategoryAsync(adminClient);
+
+        await AssignCategoryAsync(adminClient, delta, category);
+
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+        var items = await GetSetsAsync(client, $"?category={category.Id}");
+
+        items.Select(i => i.Id).Should().BeEquivalentTo([delta.Id]);
+    }
+
+    [Fact]
+    public async Task GetSetList_FilteredByUnknownCategory_ShouldReturn404WithProblemDetails()
+    {
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var response = await client.GetAsync("sheetmusic/sets?category=no-such-category-xyz");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var problem = await response.Content.ReadFromJsonAsync<ProblemResponse>(JsonDefaults.Options);
+        problem.Should().NotBeNull();
+        problem!.Detail.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task GetSetList_FilteredByCategory_ShouldHonourSearchFilterOrderByAndPaging()
+    {
+        var seeded = await GetCorpusAsync();
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var category = await CreateCategoryAsync(adminClient);
+
+        var categorized = new[] { "Charlie", "Golf", "Bravo" }.Select(n => CorpusSet(seeded, n)).ToList();
+        foreach (var set in categorized)
+            await AssignCategoryAsync(adminClient, set, category);
+
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var searched = await GetSetsAsync(client, $"?category={category.Id}&{SearchValue(Marker)}");
+        searched.Select(i => i.Id).Should().BeEquivalentTo(categorized.Select(s => s.Id));
+
+        var filtered = await GetSetsAsync(client, $"?category={category.Id}&{FilterValue($"composer eq '{Composer(1)}'")}");
+        filtered.Select(i => i.Id).Should().BeEquivalentTo(categorized.Select(s => s.Id));
+
+        var ordered = await GetSetsAsync(client, $"?category={category.Id}&$orderby=title desc");
+        ordered.Select(i => i.Title).Should().Equal([TitleOf("Golf"), TitleOf("Charlie"), TitleOf("Bravo")]);
+
+        var paged = await GetSetsAsync(client, $"?category={category.Id}&$orderby=title asc&$skip=1&$top=1");
+        paged.Select(i => i.Title).Should().Equal([TitleOf("Charlie")]);
+    }
+
+    #endregion
+
+    #region combinations
+
+    [Fact]
+    public async Task GetSetList_WithSearchAndFilter_ShouldApplyBoth()
+    {
+        var seeded = await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, $"{Search(Marker)}&{FilterValue($"title eq '{CorpusSet(seeded, "Golf").Title}'")}");
+
+        items.Should().ContainSingle();
+        items[0].Title.Should().Be(TitleOf("Golf"));
+    }
+
+    [Fact]
+    public async Task GetSetList_WithSearchAndNonMatchingFilter_ShouldReturnEmptyArray()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var items = await GetSetsAsync(client, $"{Search(Marker)}&{FilterValue("title eq 'a title no set has'")}");
+
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSetList_WithAllQueryOptionsCombined_ShouldApplyThemTogether()
+    {
+        await GetCorpusAsync();
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var query = $"{Search(Marker)}&{FilterValue($"composer eq '{Composer(1)}'")}&$orderby=title asc&$skip=1&$top=2&$expand=parts";
+        var items = await GetSetsAsync(client, query);
+
+        items.Select(i => i.Title).Should().Equal([TitleOf("Charlie"), TitleOf("Golf")]);
+        items.Should().OnlyContain(s => s.Parts != null);
+    }
+
+    #endregion
+
+    #region helpers
+
+    private sealed record CorpusSpec(string Name, int ComposerIndex, int ArrangerIndex, int AgentIndex);
+
+    private sealed record ProblemResponse(int? Status, string? Title, string? Type, string? Detail);
+
+    private static string TitleOf(string name) => $"{Marker} {name}";
+
+    private static string Composer(int index) => $"{Marker}Composer{index}";
+
+    private static string Arranger(int index) => $"{Marker}Arranger{index}";
+
+    private static string Agent(int index) => $"{Marker}Agent{index}";
+
+    private static ApiSet CorpusSet(List<ApiSet> sets, string name) => sets.Single(s => s.Title == TitleOf(name));
+
+    private static string Search(string term) => $"?{SearchValue(term)}";
+
+    private static string SearchValue(string term) => $"$search={Uri.EscapeDataString(term)}";
+
+    private static string Filter(string filter) => $"?{FilterValue(filter)}";
+
+    private static string FilterValue(string filter) => $"$filter={Uri.EscapeDataString(filter)}";
+
+    private static string? SortKey(ApiSet set, string field) => field switch
+    {
+        "title" => set.Title,
+        "composer" => set.Composer,
+        "arranger" => set.Arranger,
+        "soleSellingAgent" => set.SoleSellingAgent,
+        "archiveNumber" => set.ArchiveNumber.ToString("D9"),
+        _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unmapped sort field")
+    };
+
+    private static async Task<List<ApiSet>> GetSetsAsync(HttpClient client, string query)
+    {
+        var response = await client.GetAsync($"sheetmusic/sets{query}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var items = await response.Content.ReadFromJsonAsync<List<ApiSet>>(JsonDefaults.Options);
+        items.Should().NotBeNull();
+
+        return items!;
+    }
+
+    private static async Task AssertBadRequestAsync(HttpClient client, string query)
+    {
+        var response = await client.GetAsync($"sheetmusic/sets{query}");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, "invalid consumer input must never produce a 500");
+
+        var problem = await response.Content.ReadFromJsonAsync<ProblemResponse>(JsonDefaults.Options);
+        problem.Should().NotBeNull();
+        problem!.Status.Should().Be((int)HttpStatusCode.BadRequest);
+        problem.Detail.Should().NotBeNullOrWhiteSpace();
+    }
+
+    private async Task<List<ApiSet>> GetCorpusAsync()
+    {
+        if (corpus is not null)
+            return corpus;
+
+        await CorpusLock.WaitAsync();
+
+        try
+        {
+            if (corpus is not null)
+                return corpus;
+
+            var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+            var created = new List<ApiSet>();
+
+            foreach (var spec in CorpusSpecs)
+            {
+                created.Add(await CreateSetAsync(
+                    adminClient,
+                    TitleOf(spec.Name),
+                    Composer(spec.ComposerIndex),
+                    Arranger(spec.ArrangerIndex),
+                    Agent(spec.AgentIndex)));
+            }
+
+            corpus = created;
+            return corpus;
+        }
+        finally
+        {
+            CorpusLock.Release();
+        }
+    }
+
+    private static async Task<ApiSet> CreateSetAsync(HttpClient adminClient, string title, string? composer = null, string? arranger = null, string? soleSellingAgent = null)
+    {
+        var response = await adminClient.PostAsJsonAsync("sheetmusic/sets", new
+        {
+            Title = title,
+            Composer = composer,
+            Arranger = arranger,
+            SoleSellingAgent = soleSellingAgent
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var set = await response.Content.ReadFromJsonAsync<ApiSet>(JsonDefaults.Options);
+        set.Should().NotBeNull();
+
+        return set!;
+    }
+
+    private static async Task AddPartToSetAsync(HttpClient adminClient, ApiSet set, string partName)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{partName}.pdf");
+        await File.WriteAllTextAsync(path, "not-a-real-pdf");
+
+        await FileUploader.UploadOneFile(path, adminClient, $"sheetmusic/sets/{set.Id}/parts/{partName}/content?api-version=2.0");
+    }
+
+    private static async Task<ApiCategory> CreateCategoryAsync(HttpClient adminClient)
+    {
+        var response = await adminClient.PostAsJsonAsync("categories", new { Name = $"SetListCategory-{Guid.NewGuid()}", Inactive = false });
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var category = await response.Content.ReadFromJsonAsync<ApiCategory>(JsonDefaults.Options);
+        category.Should().NotBeNull();
+
+        return category!;
+    }
+
+    private static async Task AssignCategoryAsync(HttpClient adminClient, ApiSet set, ApiCategory category)
+    {
+        var response = await adminClient.PostAsJsonAsync($"sheetmusic/sets/{set.Id}/categories", new { CategoryIdentifier = category.Id.ToString() });
+        response.IsSuccessStatusCode.Should().BeTrue();
+    }
+
+    #endregion
+}

--- a/src/SheetMusic.Api.Test/Sets/SetTests.cs
+++ b/src/SheetMusic.Api.Test/Sets/SetTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Moq;
 using SheetMusic.Api.BlobStorage;
 using SheetMusic.Api.Parts.ViewModels;
@@ -19,7 +19,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace SheetMusic.Api.Test.Tests;
+namespace SheetMusic.Api.Test.Sets;
 
 [Collection(Collections.Set)]
 public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusicWebAppFactory>

--- a/src/SheetMusic.Api/CQRS/Query/GetCategoryCollection.cs
+++ b/src/SheetMusic.Api/CQRS/Query/GetCategoryCollection.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.OData;
+using SheetMusic.Api.OData.Extensions;
 using SheetMusic.Api.OData.MVC;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SheetMusic.Api/CQRS/Query/GetSets.cs
+++ b/src/SheetMusic.Api/CQRS/Query/GetSets.cs
@@ -1,9 +1,10 @@
-﻿using MediatR;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.OData;
 using SheetMusic.Api.OData.Expression;
+using SheetMusic.Api.OData.Extensions;
 using SheetMusic.Api.OData.MVC;
 using System;
 using System.Collections.Generic;

--- a/src/SheetMusic.Api/Controllers/SheetMusicController.cs
+++ b/src/SheetMusic.Api/Controllers/SheetMusicController.cs
@@ -29,6 +29,8 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 {
     private const long MaxFileSize = 300000000L; //300 MB
 
+    private const string SupportedSetExpand = "parts";
+
     /// <summary>
     /// Gets complete list of sheet music sets (without parts), or the ones matching <paramref name="queryParams.Search"/> if provided
     /// Use ZipDownloadUrl for complete parts download and PartsUrl to list parts
@@ -40,6 +42,15 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     [HttpGet("sets")]
     public async Task<IActionResult> GetSetList(ODataQueryParams queryParams, string? category)
     {
+        var unsupportedExpands = queryParams.Expand
+            .Where(e => !string.Equals(e, SupportedSetExpand, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (unsupportedExpands.Count > 0)
+            throw new InvalidQueryParametersError($"Unsupported $expand value(s): {string.Join(", ", unsupportedExpands)}. Supported values: {SupportedSetExpand}");
+
+        var expandParts = queryParams.Expand.Any(e => string.Equals(e, SupportedSetExpand, StringComparison.OrdinalIgnoreCase));
+
         Guid? categoryId = null;
 
         if (!string.IsNullOrWhiteSpace(category))
@@ -58,7 +69,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         {
             ZipDownloadUrl = $"{BaseUrl}/sets/{s.Id}/zip",
             PartsUrl = $"{BaseUrl}/sets/{s.Id}/parts",
-            Parts = queryParams.Expand.Contains("parts") ?
+            Parts = expandParts ?
                 s.Parts.Select(p => new ApiSheetMusicPart(p)
                 {
                     PdfDownloadUrl = $"{BaseUrl}/sets/{p.SetId}/parts/{p.MusicPartId}/pdf",

--- a/src/SheetMusic.Api/Errors/ErrorHandlerMiddleware.cs
+++ b/src/SheetMusic.Api/Errors/ErrorHandlerMiddleware.cs
@@ -18,18 +18,38 @@ public class ErrorHandlerMiddleware(RequestDelegate next, ILogger<ErrorHandlerMi
         }
         catch (ExceptionBase eb)
         {
+            logger.LogError(eb, eb.Message);
+
             var errorType = eb.GetType().Name;
             var error = new ProblemDetails { Status = (int)eb.StatusCode, Type = errorType, Title = errorType, Detail = eb.Message };
 
-            context.Response.StatusCode = (int)eb.StatusCode;
-            context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(JsonConvert.SerializeObject(error));
-            logger.LogError(eb, eb.Message);
+            await WriteProblemDetailsAsync(context, error);
         }
         catch (Exception ex)
         {
-            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
             logger.LogError(ex, "Unhandled error occured");
+
+            // Never echo the exception details back to the caller - they may contain sensitive information.
+            var error = new ProblemDetails
+            {
+                Status = (int)HttpStatusCode.InternalServerError,
+                Type = "InternalServerError",
+                Title = "InternalServerError",
+                Detail = "An unexpected error occurred while processing the request."
+            };
+
+            await WriteProblemDetailsAsync(context, error);
         }
+    }
+
+    private static async Task WriteProblemDetailsAsync(HttpContext context, ProblemDetails error)
+    {
+        if (context.Response.HasStarted)
+            return;
+
+        context.Response.Clear();
+        context.Response.StatusCode = error.Status ?? (int)HttpStatusCode.InternalServerError;
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(JsonConvert.SerializeObject(error));
     }
 }

--- a/src/SheetMusic.Api/Errors/InvalidQueryParametersError.cs
+++ b/src/SheetMusic.Api/Errors/InvalidQueryParametersError.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Net;
+
+namespace SheetMusic.Api.Errors;
+
+/// <summary>
+/// Raised when consumer supplied query parameters (OData or otherwise) cannot be understood.
+/// Surfaces as a 400 Bad Request with a ProblemDetails body instead of a bare 500.
+/// </summary>
+public class InvalidQueryParametersError : ExceptionBase
+{
+    public InvalidQueryParametersError(string message) : base(message)
+    {
+    }
+
+    public InvalidQueryParametersError(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    public override HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+}

--- a/src/SheetMusic.Api/OData/Extensions/ODataQueryParamsExtensions.cs
+++ b/src/SheetMusic.Api/OData/Extensions/ODataQueryParamsExtensions.cs
@@ -1,4 +1,5 @@
-﻿using SheetMusic.Api.OData.Constants;
+﻿using SheetMusic.Api.Errors;
+using SheetMusic.Api.OData.Constants;
 using SheetMusic.Api.OData.Expression;
 using SheetMusic.Api.OData.MVC;
 using System;
@@ -6,7 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace SheetMusic.Api.OData;
+namespace SheetMusic.Api.OData.Extensions;
 
 public static class ODataQueryParamsExtensions
 {
@@ -23,8 +24,15 @@ public static class ODataQueryParamsExtensions
 
     public static IQueryable<T> ApplyODataFilters<T>(this IQueryable<T> items, ODataQueryParams queryParams, Action<ODataFieldMapping<T>> mapFields)
     {
-        var builder = new ODataFilterExpressionBuilder<T>(queryParams.Filter, mapFields);
-        return items.Where(builder.FilterLambda);
+        try
+        {
+            var builder = new ODataFilterExpressionBuilder<T>(queryParams.Filter, mapFields);
+            return items.Where(builder.FilterLambda);
+        }
+        catch (Exception ex) when (ex is not ExceptionBase)
+        {
+            throw new InvalidQueryParametersError($"Invalid $filter clause: {ex.Message}", ex);
+        }
     }
 
     /// <summary>
@@ -43,7 +51,17 @@ public static class ODataQueryParamsExtensions
         IOrderedQueryable<T>? ordered = null;
         foreach (var option in queryParams.OrderBy)
         {
-            var keySelector = fieldMapping.GetMapping(option.Field);
+            LambdaExpression keySelector;
+
+            try
+            {
+                keySelector = fieldMapping.GetMapping(option.Field);
+            }
+            catch (Exception ex) when (ex is not ExceptionBase)
+            {
+                throw new InvalidQueryParametersError($"Invalid $orderby clause: {ex.Message}", ex);
+            }
+
             ordered = ordered is null
                 ? InvokeOrderMethod(items, keySelector, option.Direction == SortDirection.desc ? nameof(Queryable.OrderByDescending) : nameof(Queryable.OrderBy))
                 : InvokeOrderMethod(ordered, keySelector, option.Direction == SortDirection.desc ? nameof(Queryable.ThenByDescending) : nameof(Queryable.ThenBy));

--- a/src/SheetMusic.Api/OData/MVC/ODataParamResolver.cs
+++ b/src/SheetMusic.Api/OData/MVC/ODataParamResolver.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using SheetMusic.Api.Errors;
 using SheetMusic.Api.OData.Constants;
 using System;
 using System.Collections.Generic;
@@ -23,55 +24,91 @@ public class ODataParamResolver : IModelBinder
         };
 
         if (param.Top < 1)
-            throw new InvalidOperationException("Top must be at least 1 row");
+            throw new InvalidQueryParametersError("$top must be at least 1 row");
+
+        if (param.Skip < 0)
+            throw new InvalidQueryParametersError("$skip cannot be negative");
 
         var filter = GetStringParam(bindingContext, "$filter");
         var order = GetStringParam(bindingContext, "$orderby");
-
         var expand = GetStringParam(bindingContext, "$expand");
 
         if (expand != null)
-        {
-            try
-            {
-                param.Expand = new List<string>(expand.Split(','));
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException("Invalid expand clause", ex);
-            }
-        }
+            param.Expand = ParseExpand(expand);
 
-        if (order != null)
-        {
-            try
-            {
-                var orderoptions = order.Split(',')
-                    .Select(t => t.Trim().Split(' ')).Select(t => new ODataOrderByOption()
-                    {
-                        Field = t[0].Trim(),
-                        Direction = t.Length == 1 ? SortDirection.asc : t[1].Trim() == "asc" ? SortDirection.asc : SortDirection.desc
-                    });
-                param.OrderBy = orderoptions.ToList();
-            }
-            catch (Exception ex)
-            {
-                throw new ArgumentException("Invalid order by clause", ex);
-            }
-        }
-        else
-        {
-            param.OrderBy = new List<ODataOrderByOption>();
-        }
+        param.OrderBy = order != null ? ParseOrderBy(order) : new List<ODataOrderByOption>();
 
         if (filter != null)
-            param.Filter = ODataParser.Parse(filter);
+            param.Filter = ParseFilter(filter);
 
         bindingContext.Result = ModelBindingResult.Success(param);
 
         return Task.CompletedTask;
     }
 
+    private static List<string> ParseExpand(string expand)
+    {
+        if (string.IsNullOrWhiteSpace(expand))
+            throw new InvalidQueryParametersError("$expand cannot be empty");
+
+        var options = expand.Split(',').Select(o => o.Trim()).ToList();
+
+        if (options.Any(string.IsNullOrEmpty))
+            throw new InvalidQueryParametersError($"Invalid $expand clause '{expand}'");
+
+        return options;
+    }
+
+    private static List<ODataOrderByOption> ParseOrderBy(string order)
+    {
+        if (string.IsNullOrWhiteSpace(order))
+            throw new InvalidQueryParametersError("$orderby cannot be empty");
+
+        return order.Split(',')
+            .Select(clause => ParseOrderByClause(clause, order))
+            .ToList();
+    }
+
+    private static ODataOrderByOption ParseOrderByClause(string clause, string fullClause)
+    {
+        var tokens = clause.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (tokens.Length is 0 or > 2)
+            throw new InvalidQueryParametersError($"Invalid $orderby clause '{fullClause}'. Expected format: 'field [asc|desc]'");
+
+        var direction = SortDirection.asc;
+
+        if (tokens.Length == 2)
+        {
+            if (string.Equals(tokens[1], "asc", StringComparison.OrdinalIgnoreCase))
+                direction = SortDirection.asc;
+            else if (string.Equals(tokens[1], "desc", StringComparison.OrdinalIgnoreCase))
+                direction = SortDirection.desc;
+            else
+                throw new InvalidQueryParametersError($"Invalid sort direction '{tokens[1]}' in $orderby clause '{fullClause}'. Must be 'asc' or 'desc'");
+        }
+
+        return new ODataOrderByOption
+        {
+            Field = tokens[0],
+            Direction = direction
+        };
+    }
+
+    private static ODataExpression ParseFilter(string filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+            throw new InvalidQueryParametersError("$filter cannot be empty");
+
+        try
+        {
+            return ODataParser.Parse(filter);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidQueryParametersError($"Invalid $filter clause '{filter}'", ex);
+        }
+    }
 
     private static string? GetStringParam(ModelBindingContext bindingContext, string fieldName)
     {
@@ -87,14 +124,18 @@ public class ODataParamResolver : IModelBinder
     private static int? GetIntParam(ModelBindingContext bindingContext, string fieldName)
     {
         var valueProviderResult = bindingContext.ValueProvider.GetValue(fieldName);
-        if (valueProviderResult != ValueProviderResult.None)
-        {
-            var value = valueProviderResult.FirstValue;
-            if (int.TryParse(value, out var fvalue))
-                return fvalue;
-        }
-        return null;
-    }
+        if (valueProviderResult == ValueProviderResult.None)
+            return null;
 
+        var value = valueProviderResult.FirstValue;
+
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidQueryParametersError($"{fieldName} cannot be empty");
+
+        if (!int.TryParse(value, out var parsed))
+            throw new InvalidQueryParametersError($"{fieldName} must be a whole number, but was '{value}'");
+
+        return parsed;
+    }
 }
 

--- a/src/SheetMusic.Api/OData/MVC/ODataQueryParams.cs
+++ b/src/SheetMusic.Api/OData/MVC/ODataQueryParams.cs
@@ -27,7 +27,7 @@ public class ODataQueryParams
     public List<string> Expand { get; set; } = new List<string>();
 
     public bool HasFilter => Filter != null;
-    public bool HasSearch => !string.IsNullOrEmpty(Search);
+    public bool HasSearch => !string.IsNullOrWhiteSpace(Search);
     public bool IsEmpty => Top == null && Skip == null && !OrderBy.Any() && Filter == null && string.IsNullOrWhiteSpace(Search);
 }
 

--- a/src/SheetMusic.Api/OData/ODataParser.cs
+++ b/src/SheetMusic.Api/OData/ODataParser.cs
@@ -6,30 +6,24 @@ using System.Text.RegularExpressions;
 
 namespace SheetMusic.Api.OData;
 
-public class ODataParser
+public partial class ODataParser
 {
-    static List<string> operations = new List<string>() { "eq", "neq", "gt", "lt", "ge", "le", "=", "==", "!=", ">", ">=", "<", "<=", "in" };
-    static List<string> logicalOperators = new List<string>() { "and", "or", "&&", "||" };
+    static readonly List<string> operations = ["eq", "neq", "ne", "gt", "lt", "ge", "le", "=", "==", "!=", ">", ">=", "<", "<=", "in"];
+    static readonly List<string> logicalOperators = ["and", "or", "&&", "||"];
 
-    static Regex logicalGroupingPattern = new Regex($@"(\([^()]+(?:{string.Join("|", operations)})[^()]+\)|\([^()]+(?:{string.Join("|", logicalOperators)})[^()]+\))",
+    static readonly Regex logicalGroupingPattern = new($@"(\([^()]+(?:{string.Join("|", operations)})[^()]+\)|\([^()]+(?:{string.Join("|", logicalOperators)})[^()]+\))",
         RegexOptions.IgnoreCase);
 
-    private List<string[]> collectionValues = new List<string[]>();
-    private List<string> collections = new List<string>();
-    private List<string> logicalExpressions = new List<string>();
-    private List<string> values = new List<string>();
+    private readonly List<string[]> collectionValues = [];
+    private readonly List<string> collections = [];
+    private readonly List<string> logicalExpressions = [];
+    private readonly List<string> values = [];
 
     private readonly string originalFilter;
 
     private ODataParser(string filter)
     {
         originalFilter = filter;
-
-        ValidateFilter();
-    }
-
-    private void ValidateFilter()
-    {
     }
 
     private ODataExpression Parse()
@@ -38,16 +32,16 @@ public class ODataParser
         processedFilter = TrimSingleExpressionGrouping(processedFilter);
 
         // look for collections
-        processedFilter = Regex.Replace(processedFilter, @"(\((?:[,\s]*'[^']+')+\))", match =>
+        processedFilter = CollectionPattern().Replace(processedFilter, match =>
         {
             collections.Add(match.Value);
             collectionValues.Add(match.Groups[1].Value.Split(',').Select(s => s.Trim('\'')).ToArray());
             return $"__COLLECTION|{collections.Count - 1}";
         });
-        processedFilter = Regex.Replace(processedFilter, /*@"'([^']+)'"*/ @"([""'])(?:(?=(\\?))\2.)*?\1", match =>
+        processedFilter = QuotedValuePattern().Replace(processedFilter, match =>
         {
             var value = match.Groups[0].Value;
-            values.Add(value.Substring(1, value.Length - 2));
+            values.Add(value[1..^1]);
             return $"__VALUE|{values.Count - 1}";
         });
 
@@ -76,11 +70,11 @@ public class ODataParser
     private ODataExpression ProcessFilterA(string filter)
     {
         var trimmedFilter = TrimUselessGrouping(filter);
-        var tokens = Regex.Split(trimmedFilter, @"\band\b|\bor\b|\b&&\b|\b\|\|\b", RegexOptions.IgnoreCase)
+        var tokens = LogicalSplitPattern().Split(trimmedFilter)
             .Select(t => t.Trim())
             .ToArray();
 
-        var operatorMatches = Regex.Matches(trimmedFilter, $@"\s(and|or|&&|\|\|)\s", RegexOptions.IgnoreCase);
+        var operatorMatches = LogicalOperatorMatchPattern().Matches(trimmedFilter);
         var operators = operatorMatches.Cast<Match>().Select(m => m.Groups[1].Value).ToArray();
 
 
@@ -110,7 +104,7 @@ public class ODataParser
     }
 
 
-    private ODataExpression CreateExpression(string filter)
+    private ODataFilterExpression CreateExpression(string filter)
     {
         if (string.IsNullOrEmpty(filter))
             throw new InvalidOperationException("Filter cannot be empty");
@@ -140,7 +134,7 @@ public class ODataParser
             var collection = collections[collectionIndex];
             value = collection;
 
-            var collectionItemMatch = Regex.Matches(collection, "'([^']+)'");
+            var collectionItemMatch = CollectionItemPattern().Matches(collection);
             var items = collectionItemMatch.Cast<Match>().Select(g => g.Groups[1].Value).ToList();
 
             expression.IsCollection = true;
@@ -167,59 +161,48 @@ public class ODataParser
         return grp;
     }
 
-    private static FilterOperation ResolveOperation(string operation)
+    private static FilterOperation ResolveOperation(string operation) => operation.ToLower() switch
     {
-        switch (operation.ToLower())
-        {
-            case "eq": case "=": case "==": return FilterOperation.Eq;
-            case "lt": case "<": return FilterOperation.Lt;
-            case "lteq": case "<=": return FilterOperation.Lteq;
-            case "gt": case ">": return FilterOperation.Gt;
-            case "gteq": case ">=": return FilterOperation.Gteq;
-            case "not": case "!=": return FilterOperation.Not;
-            case "in": return FilterOperation.In;
-            default:
-                throw new ArgumentException("Invalid filter operation: " + operation);
-        }
-    }
+        "eq" or "=" or "==" => FilterOperation.Eq,
+        "lt" or "<" => FilterOperation.Lt,
+        "le" or "lteq" or "<=" => FilterOperation.Lteq,
+        "gt" or ">" => FilterOperation.Gt,
+        "ge" or "gteq" or ">=" => FilterOperation.Gteq,
+        "ne" or "neq" or "not" or "!=" => FilterOperation.Not,
+        "in" => FilterOperation.In,
+        _ => throw new ArgumentException("Invalid filter operation: " + operation),
+    };
 
-    private LogicalOperator ResolveLogicalOperator(string logicalOperator)
+    private static LogicalOperator ResolveLogicalOperator(string logicalOperator) => logicalOperator.ToLower() switch
     {
-        switch (logicalOperator.ToLower())
-        {
-            case "and": case "&&": return LogicalOperator.And;
-            case "or": case "||": return LogicalOperator.Or;
-            default:
-                throw new InvalidOperationException("Invalid logical operator: " + logicalOperator);
-        }
-    }
-
+        "and" or "&&" => LogicalOperator.And,
+        "or" or "||" => LogicalOperator.Or,
+        _ => throw new InvalidOperationException("Invalid logical operator: " + logicalOperator),
+    };
 
     private static string TrimSingleExpressionGrouping(string filter)
     {
-        var operatorList = string.Join("|", operations);
-        var expression = @"\([^()]+(?:eq|neq|=|!=|gt|>|lt|<|ge|>=|le|<=)[^()]+\)";
-        return Regex.Replace(filter, expression, match =>
+        return SingleExpressionGroupingPattern().Replace(filter, match =>
         {
             // Remove '' as this could contain and/or, and can't find any clean way of checking for this in a regex.
-            var cleaned = Regex.Replace(match.Value, @"'[^']+'", "removed");
+            var cleaned = QuotedTextPattern().Replace(match.Value, "removed");
 
-            if (Regex.IsMatch(cleaned, @"\s(and|or)\s"))
+            if (AndOrWhitespacePattern().IsMatch(cleaned))
                 return match.Value;
 
-            return match.Value.Substring(1, match.Value.Length - 2);
+            return match.Value[1..^1];
         });
     }
     private static string TrimUselessGrouping(string filter)
     {
-        if (Regex.IsMatch(filter, @"^\(.*\)$")) //filter.StartsWith("(") && filter.EndsWith(")"))
+        if (WrappingParenthesesPattern().IsMatch(filter))
         {
-            if (!Regex.IsMatch(filter.Substring(1, filter.Length - 2), "[()]"))
+            if (!ParenthesisCharPattern().IsMatch(filter.AsSpan(1, filter.Length - 2)))
                 // No other parenthesis in the body, we can trim the start and end
-                return filter.Substring(1, filter.Length - 2);
+                return filter[1..^1];
 
             var depth = 1;
-            foreach (var character in filter.Substring(1))
+            foreach (var character in filter[1..])
             {
                 switch (character)
                 {
@@ -233,9 +216,39 @@ public class ODataParser
             }
 
             // Trim start and end - we did not reach equality, meaning the starting ( spans the whole expression.
-            return filter.Substring(1, filter.Length - 2);
+            return filter[1..^1];
         }
 
         return filter;
     }
+
+    [GeneratedRegex(@"(\((?:[,\s]*'[^']+')+\))")]
+    private static partial Regex CollectionPattern();
+
+    [GeneratedRegex(@"([""'])(?:(?=(\\?))\2.)*?\1")]
+    private static partial Regex QuotedValuePattern();
+
+    [GeneratedRegex(@"\band\b|\bor\b|\b&&\b|\b\|\|\b", RegexOptions.IgnoreCase)]
+    private static partial Regex LogicalSplitPattern();
+
+    [GeneratedRegex(@"\s(and|or|&&|\|\|)\s", RegexOptions.IgnoreCase)]
+    private static partial Regex LogicalOperatorMatchPattern();
+
+    [GeneratedRegex("'([^']+)'")]
+    private static partial Regex CollectionItemPattern();
+
+    [GeneratedRegex(@"\([^()]+(?:eq|neq|ne|=|!=|gt|>|lt|<|ge|>=|le|<=)[^()]+\)")]
+    private static partial Regex SingleExpressionGroupingPattern();
+
+    [GeneratedRegex(@"'[^']+'")]
+    private static partial Regex QuotedTextPattern();
+
+    [GeneratedRegex(@"\s(and|or)\s")]
+    private static partial Regex AndOrWhitespacePattern();
+
+    [GeneratedRegex(@"^\(.*\)$")]
+    private static partial Regex WrappingParenthesesPattern();
+
+    [GeneratedRegex("[()]")]
+    private static partial Regex ParenthesisCharPattern();
 }

--- a/src/SheetMusic.Api/Parts/Queries/GetPartCollection.cs
+++ b/src/SheetMusic.Api/Parts/Queries/GetPartCollection.cs
@@ -1,7 +1,8 @@
-﻿using MediatR;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.OData;
+using SheetMusic.Api.OData.Extensions;
 using SheetMusic.Api.OData.MVC;
 using SheetMusic.Api.Database.Entities;
 using System.Collections.Generic;

--- a/src/SheetMusic.Api/Projects/Queries/GetProjectCollection.cs
+++ b/src/SheetMusic.Api/Projects/Queries/GetProjectCollection.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.OData;
+using SheetMusic.Api.OData.Extensions;
 using SheetMusic.Api.OData.MVC;
 using System.Collections.Generic;
 using System.Threading;


### PR DESCRIPTION
## Problem

`GET /sheetmusic/sets` returned a bare, empty **HTTP 500** for malformed `\`, `\`, `\`, `\` and `\` values, giving consumers no indication of what went wrong.

## Changes

- Added `InvalidQueryParametersError` (`ExceptionBase`, 400) and wrapped OData parsing/binding/expression-building failures in it, in `ODataParamResolver` and `ODataQueryParamsExtensions`.
- `ODataParser` now supports `ne`/`ge`/`le` filter operators (previously threw, resulting in a 500).
- `ODataParamResolver` validates `\`/`\` (non-numeric, empty, zero, negative), `\` (empty, unmapped field, bad direction, malformed clause) and `\` (empty/blank segments) up front.
- `SheetMusicController.GetSetList` validates unsupported `\` values and matches `parts` case-insensitively.
- `ErrorHandlerMiddleware` now always writes a `ProblemDetails` body, including for unhandled 500s, instead of an empty response.
- Test auth handler now returns `NoResult` for unauthenticated requests so `401` assertions are meaningful.

## Tests

- Added `GetSetListTests` covering baseline behavior, `\`, `\` (all operators, groups, `in`, malformed/unmapped/empty), `\` (all fields, multi-clause, malformed), `\`/`\` (paging, invalid values), `\`, `category` filtering, and combinations - asserting every invalid-input case returns `400` with a `ProblemDetails` body.
- Moved Sets-domain tests (`SetTests`, `GetSetListTests`) into a dedicated `Sets/` test folder, matching the existing `Parts/` domain-folder convention.

Fixes #203