### PR TITLE
fix: remove Newtonsoft.Json and revert incompatible Microsoft.OpenApi bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    ignore:
+      # Swashbuckle.AspNetCore 10.2.3 (latest) still depends on Microsoft.OpenApi 2.7.5.
+      # Bumping past that breaks Swagger generation at runtime with a MissingMethodException
+      # (IOpenApiRequestBody.get_Content()). Remove this ignore once Swashbuckle ships support
+      # for Microsoft.OpenApi 3.x, or once the API migrates to Scalar (see tracking issue).
+      - dependency-name: "Microsoft.OpenApi"
+        versions: [">= 3.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/src/SheetMusic.Api/BlobStorage/BlobClient.cs
+++ b/src/SheetMusic.Api/BlobStorage/BlobClient.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Azure.Storage;
-using Microsoft.Azure.Storage.Blob;
+﻿using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SheetMusic.Api.Errors;
@@ -13,13 +12,9 @@ public class BlobClient(IConfiguration configuration) : IBlobClient
 {
     private const string ContainerName = "sheet-music";
 
-    private CloudBlobContainer GetContainer()
+    private BlobContainerClient GetContainer()
     {
-        var storageAccount = CloudStorageAccount.Parse(configuration.GetConnectionString("AzureStorageConnectionString"));
-        var blobClient = storageAccount.CreateCloudBlobClient();
-        var container = blobClient.GetContainerReference(ContainerName);
-
-        return container;
+        return new BlobContainerClient(configuration.GetConnectionString("AzureStorageConnectionString"), ContainerName);
     }
 
     public async Task EnsureContainerExistsAsync()
@@ -33,7 +28,7 @@ public class BlobClient(IConfiguration configuration) : IBlobClient
         var blob = GetBlob(identifier);
 
         using var memoryStream = new MemoryStream();
-        await blob.DownloadToStreamAsync(memoryStream);
+        await blob.DownloadToAsync(memoryStream);
         await memoryStream.FlushAsync();
         return memoryStream.ToArray();
     }
@@ -50,7 +45,7 @@ public class BlobClient(IConfiguration configuration) : IBlobClient
         try
         {
             var blob = GetBlob(identifier);
-            await blob.UploadFromStreamAsync(contentStream);
+            await blob.UploadAsync(contentStream, overwrite: true);
         }
         catch (Exception ex)
         {
@@ -58,21 +53,19 @@ public class BlobClient(IConfiguration configuration) : IBlobClient
         }
     }
 
-    private CloudBlockBlob GetBlob(PartRelatedToSet identifier)
+    private Azure.Storage.Blobs.BlobClient GetBlob(PartRelatedToSet identifier)
     {
         var container = GetContainer();
-        return container.GetBlockBlobReference(identifier.BlobPath);
+        return container.GetBlobClient(identifier.BlobPath);
     }
 
     public async Task DeleteSetContentAsync(Guid id)
     {
         var container = GetContainer();
-        var parts = await container.GetDirectoryReference(id.ToString()).ListBlobsSegmentedAsync(new BlobContinuationToken());
 
-        foreach (var part in parts.Results)
+        await foreach (var blobItem in container.GetBlobsAsync(prefix: $"{id}/"))
         {
-            var blobPart = part as CloudBlockBlob;
-            blobPart?.DeleteIfExistsAsync();
+            await container.DeleteBlobIfExistsAsync(blobItem.Name);
         }
     }
 
@@ -80,7 +73,13 @@ public class BlobClient(IConfiguration configuration) : IBlobClient
     {
         var blob = GetBlob(identifier);
 
-        return await blob.ExistsAsync() && blob.Properties.Length > 0;
+        if (!await blob.ExistsAsync())
+        {
+            return false;
+        }
+
+        var properties = await blob.GetPropertiesAsync();
+        return properties.Value.ContentLength > 0;
     }
 
     public async Task DeletePartContentAsync(PartRelatedToSet identifier)
@@ -89,3 +88,4 @@ public class BlobClient(IConfiguration configuration) : IBlobClient
         await blob.DeleteIfExistsAsync();
     }
 }
+

--- a/src/SheetMusic.Api/Errors/ErrorHandlerMiddleware.cs
+++ b/src/SheetMusic.Api/Errors/ErrorHandlerMiddleware.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Net;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace SheetMusic.Api.Errors;
@@ -50,6 +50,6 @@ public class ErrorHandlerMiddleware(RequestDelegate next, ILogger<ErrorHandlerMi
         context.Response.Clear();
         context.Response.StatusCode = error.Status ?? (int)HttpStatusCode.InternalServerError;
         context.Response.ContentType = "application/json";
-        await context.Response.WriteAsync(JsonConvert.SerializeObject(error));
+        await context.Response.WriteAsync(JsonSerializer.Serialize(error));
     }
 }

--- a/src/SheetMusic.Api/SheetMusic.Api.csproj
+++ b/src/SheetMusic.Api/SheetMusic.Api.csproj
@@ -20,8 +20,8 @@
 		<PackageReference Include="MediatR" Version="14.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
 		<PackageReference Include="Azure.Search.Documents" Version="11.6.0" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
@@ -29,7 +29,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.OpenApi" Version="3.9.0" />
+		<PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
 		<PackageReference Include="Resend" Version="0.6.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.3" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />

--- a/src/SheetMusic.ImportCli/FolderImporter.cs
+++ b/src/SheetMusic.ImportCli/FolderImporter.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using SheetMusic.Api.Controllers.RequestModels;
+﻿using SheetMusic.Api.Controllers.RequestModels;
 using SheetMusic.Api.Controllers.ViewModels;
 using System;
 using System.IO;
@@ -7,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -55,7 +55,7 @@ public class FolderImporter
             }
             else
             {
-                set = JsonConvert.DeserializeObject<ApiSet>(await setResponse.Content.ReadAsStringAsync());
+                set = JsonSerializer.Deserialize<ApiSet>(await setResponse.Content.ReadAsStringAsync(), JsonDefaults.Options);
             }
 
             foreach (var fileInfo in folderInfo.GetFiles())
@@ -110,7 +110,7 @@ public class FolderImporter
             Title = name,
         };
 
-        var content = new StringContent(JsonConvert.SerializeObject(parameters), Encoding.UTF8, "application/json");
+        var content = new StringContent(JsonSerializer.Serialize(parameters), Encoding.UTF8, "application/json");
         var response = await client.PostAsync("sheetmusic/sets", content);
 
         response.EnsureSuccessStatusCode();

--- a/src/SheetMusic.ImportCli/HttpClientExtensions.cs
+++ b/src/SheetMusic.ImportCli/HttpClientExtensions.cs
@@ -1,11 +1,18 @@
-﻿using Newtonsoft.Json;
-using System.Net.Http;
+﻿using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace SheetMusic.ImportCli;
 
 public static class HttpClientExtensions
 {
+    private sealed class TokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; set; } = string.Empty;
+    }
+
     public static async Task<HttpClient> DecorateWithAuthHeaderAsync(this HttpClient client, string username, string password)
     {
         var content = new MultipartFormDataContent
@@ -17,8 +24,8 @@ public static class HttpClientExtensions
 
         var response = await client.PostAsync("token", content);
         var responseString = await response.Content.ReadAsStringAsync();
-        var token = JsonConvert.DeserializeAnonymousType(responseString, new { access_token = string.Empty });
-        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token.access_token}");
+        var token = JsonSerializer.Deserialize<TokenResponse>(responseString, JsonDefaults.Options);
+        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token?.AccessToken}");
 
         return client;
     }

--- a/src/SheetMusic.ImportCli/JsonDefaults.cs
+++ b/src/SheetMusic.ImportCli/JsonDefaults.cs
@@ -1,0 +1,13 @@
+using System.Text.Json;
+
+namespace SheetMusic.ImportCli;
+
+/// <summary>
+/// Shared System.Text.Json options for the import CLI. Uses the "Web" defaults
+/// (camelCase, case-insensitive matching) to mirror ASP.NET Core's default controller
+/// serialization behavior when reading API responses back into PascalCase DTOs.
+/// </summary>
+public static class JsonDefaults
+{
+    public static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+}

--- a/src/SheetMusic.ImportCli/SheetMusic.ImportCli.csproj
+++ b/src/SheetMusic.ImportCli/SheetMusic.ImportCli.csproj
@@ -7,10 +7,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\SheetMusic.Api\SheetMusic.Api.csproj" />
 	</ItemGroup>
 

--- a/src/SheetMusic.ImportCli/SingleZipFileImporter.cs
+++ b/src/SheetMusic.ImportCli/SingleZipFileImporter.cs
@@ -1,8 +1,8 @@
-﻿using Newtonsoft.Json;
-using SheetMusic.Api.Controllers.ViewModels;
+﻿using SheetMusic.Api.Controllers.ViewModels;
 using System;
 using System.IO;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace SheetMusic.ImportCli;
@@ -32,7 +32,7 @@ public class SingleZipFileImporter
 
             var set = await client.GetAsync($"sheetmusic/sets/{archiveNumber}/parts");
 
-            var content = JsonConvert.DeserializeObject<ApiSet>(await set.Content.ReadAsStringAsync());
+            var content = JsonSerializer.Deserialize<ApiSet>(await set.Content.ReadAsStringAsync(), JsonDefaults.Options);
 
             if (content.Parts == null || content.Parts.Count == 0)
             {


### PR DESCRIPTION
## Summary

- Removes all direct usage of `Newtonsoft.Json` across the solution, replacing it with `System.Text.Json`:
  - `ErrorHandlerMiddleware` (API error responses)
  - `SheetMusic.ImportCli` (`FolderImporter`, `SingleZipFileImporter`, `HttpClientExtensions`) — added a shared `JsonDefaults` options helper and a typed `TokenResponse` model to replace `JsonConvert.DeserializeAnonymousType`.
  - Removed the direct `Newtonsoft.Json` package reference from `SheetMusic.ImportCli.csproj`.
- Removes the last **transitive** vulnerable `Newtonsoft.Json 10.0.2` dependency by replacing the deprecated `Microsoft.Azure.Storage.Blob` SDK with the modern `Azure.Storage.Blobs` SDK in `BlobClient`. This was flagged by NuGet as `NU1903` (GHSA-5crp-9r3c-p9vr).
- Reverts an incompatible dependency bump: `Microsoft.OpenApi` was bumped from `2.7.5` to `3.9.0` in #212, but the latest `Swashbuckle.AspNetCore` release (`10.2.3`) is still built against `Microsoft.OpenApi 2.7.5` and is binary-incompatible with `3.x` (`MissingMethodException` on `IOpenApiRequestBody.get_Content()` during Swagger generation). This broke 7 tests in `ODataSwaggerDocumentationTests`. Reverted the pin back to `2.7.5` to fix them.
- Added a Dependabot ignore rule for `Microsoft.OpenApi >= 3.0.0` so this doesn't silently recur, until Swashbuckle is dropped (see #220) or ships 3.x support.

## Related

- Fixes the Newtonsoft.Json vulnerability across the whole solution (direct + transitive).
- Follow-up tracked in #220: migrate off Swashbuckle to Scalar / native `Microsoft.AspNetCore.OpenApi` so `Microsoft.OpenApi` can be upgraded freely again.

## Testing

- `dotnet build src/SheetMusic.sln` — succeeds, no `NU1903` warnings.
- `dotnet test src/SheetMusic.Api.Test` — 233/233 passing.