### PR TITLE
docs: add descriptions and response docs on all REST endpoints

### DIFF
--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -57,6 +57,14 @@ ASP.NET Core 8.0 Web API for managing sheet music collections. Uses CQRS, Mediat
 - Return `ActionResult<T>` or `ActionResult`
 - Primary constructors with `IMediator mediator`
 
+### REST endpoint documentation
+`PartsController` and `CategoriesController` are the reference standard - follow their shape for every controller/action:
+- Controller-level `<summary>` describing the resource and any privilege requirements
+- Per-action `<summary>` describing what the endpoint does
+- `<param>` for every route/query/body parameter
+- `<response code="...">` for every status code the action can produce (success plus `400`/`401`/`403`/`404`/`409`, etc.), matching the `StatusCode` of exceptions the underlying command/query can throw
+- Prefer `ActionResult<T>` over `IActionResult` so Swagger can infer the response schema
+
 ### Database
 - EF Core with SQL Server
 - `Guid` for entity IDs

--- a/.github/instructions/vscode-settings.instructions.md
+++ b/.github/instructions/vscode-settings.instructions.md
@@ -1,0 +1,9 @@
+---
+description: Reminder to commit shared VS Code workspace settings
+applyTo: '.vscode/**'
+---
+
+# VS Code workspace settings
+
+- `.vscode/settings.json` is shared, checked-in workspace configuration, not a personal/local file. It is sometimes updated during development (e.g. when adding recommended extensions config, formatting rules, or task definitions).
+- Any change to `.vscode/settings.json` must be committed along with the rest of the change - do not leave it as an uncommitted or stashed-only change.

--- a/src/SheetMusic.Api/Controllers/SheetMusicController.cs
+++ b/src/SheetMusic.Api/Controllers/SheetMusicController.cs
@@ -20,6 +20,12 @@ using System.Threading.Tasks;
 
 namespace SheetMusic.Api.Controllers;
 
+/// <summary>
+/// This controller contains endpoints for managing sheet music Set resources, including the parts (PDF files)
+/// assigned to a set and the categories assigned to a set.
+///
+/// PS! Creating, updating and deleting sets, categories on a set and part content require Administrator privileges.
+/// </summary>
 [Authorize]
 [ApiController]
 [Route("sheetmusic")]
@@ -38,6 +44,10 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="queryParams">Optional. OData support for $filter</param>
     /// <param name="category">Optional. Filter sets by category, identified by guid or name</param>
     /// <returns>Sets matching criteria</returns>
+    /// <response code="200">A list of sets matching filter, or all sets. Empty list if no matching results</response>
+    /// <response code="400">If an unsupported $expand value is provided</response>
+    /// <response code="404">Category was not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [Produces("application/json", Type = typeof(List<ApiSet>))]
     [HttpGet("sets")]
     public async Task<IActionResult> GetSetList(ODataQueryParams queryParams, string? category)
@@ -87,6 +97,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// </summary>
     /// <param name="identifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <returns>List of parts for set</returns>
+    /// <response code="200">Set information including its parts</response>
+    /// <response code="404">Set not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [Produces("application/json", Type = typeof(ApiSet))]
     [HttpGet("sets/{identifier}/parts")]
     public async Task<ActionResult<ApiSet>> GetPartsForSet(string identifier)
@@ -118,7 +131,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="partIdentifier">A value uniquely identifying part. Either guid or part name</param>
     /// <returns>The part that matches, 404 if not found</returns>
-
+    /// <response code="200">The part matching the identifiers</response>
+    /// <response code="404">Set, part, or the relationship between them was not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [Produces("application/json", Type = typeof(ApiSheetMusicPart))]
     [HttpGet("sets/{setIdentifier}/parts/{partIdentifier}")]
     public async Task<IActionResult> GetSinglePart(string setIdentifier, string partIdentifier)
@@ -138,6 +153,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="partIdentifier">A value uniquely identifying part. Either guid or part name</param>
     /// <param name="downloadToken">A token to prove you are authorized for download</param>
     /// <returns>The PDF file, if it exists. 404 otherwise.</returns>
+    /// <response code="200">The PDF file content</response>
+    /// <response code="400">If the download token is missing or invalid</response>
+    /// <response code="404">Set, part, or the relationship between them was not found</response>
     [AllowAnonymous]
     [Produces("application/pdf")]
     [HttpGet("sets/{setIdentifier}/parts/{partIdentifier}/pdf")]
@@ -165,6 +183,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// </summary>
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <returns>Set matching <paramref name="setIdentifier"/></returns>
+    /// <response code="200">The set matching the identifier</response>
+    /// <response code="404">Set not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [Produces("application/json", Type = typeof(ApiSet))]
     [HttpGet("sets/{setIdentifier}")]
     public async Task<IActionResult> GetSetinformationByIdentifier(string setIdentifier)
@@ -187,6 +208,11 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="request">Update set parameters</param>
     /// <returns>Updated set metadata</returns>
+    /// <response code="200">The updated set</response>
+    /// <response code="400">If provided input is invalid. Should include a body with ProblemDetails-formatted errors.</response>
+    /// <response code="404">Set not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Produces("application/json", Type = typeof(ApiSet))]
     [Authorize(AuthPolicy.Admin)]
     [HttpPut("sets/{setIdentifier}")]
@@ -212,6 +238,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// </summary>
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <returns>List of categories assigned to the set</returns>
+    /// <response code="200">List of categories assigned to the set</response>
+    /// <response code="404">Set not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [Produces("application/json", Type = typeof(List<ApiCategory>))]
     [HttpGet("sets/{setIdentifier}/categories")]
     public async Task<IActionResult> GetCategoriesForSet(string setIdentifier)
@@ -232,6 +261,11 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="request">The category to assign, identified by guid or name</param>
     /// <returns>The updated list of categories assigned to the set</returns>
+    /// <response code="200">The updated list of categories assigned to the set</response>
+    /// <response code="404">Set or category not found</response>
+    /// <response code="409">The category is already assigned to the set</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Produces("application/json", Type = typeof(List<ApiCategory>))]
     [Authorize(AuthPolicy.Admin)]
     [HttpPost("sets/{setIdentifier}/categories")]
@@ -255,6 +289,10 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="categoryIdentifier">A value uniquely identifying category. Either guid or name</param>
     /// <returns>204 if successfull, 404 if set, category or the assignment was not found</returns>
+    /// <response code="204">Category was removed from the set successfully</response>
+    /// <response code="404">Set, category, or the assignment was not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpDelete("sets/{setIdentifier}/categories/{categoryIdentifier}")]
     public async Task<ActionResult> RemoveCategoryFromSet(string setIdentifier, string categoryIdentifier)
@@ -268,7 +306,10 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// Authorized a set for download, allowing a single download for the one with the token.
     /// </summary>
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
-    /// <returns></returns>
+    /// <returns>A one-time download token</returns>
+    /// <response code="200">The generated download token</response>
+    /// <response code="404">Set not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [HttpGet("sets/{setIdentifier}/zip/token")]
     public async Task<IActionResult> GetDownloadToken(string setIdentifier)
     {
@@ -291,6 +332,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="downloadToken">A token for proving that user is allowed to download this set</param>
     /// <returns>Zipped collection of parts</returns>
+    /// <response code="200">The zipped collection of parts</response>
+    /// <response code="400">If the download token is missing or invalid</response>
+    /// <response code="404">Set not found</response>
     [AllowAnonymous]
     [Produces("application/zip")]
     [HttpGet("sets/{setIdentifier}/zip")]
@@ -320,6 +364,8 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// If a non-empty file does not exists, the set is listed in results
     /// </summary>
     /// <returns>The sets with parts that are assigned, but a file is not present</returns>
+    /// <response code="200">The sets with parts that are assigned, but a file is not present</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [Produces("application/json")]
     [HttpGet("sets/withoutFiles")]
     public async Task<IActionResult> GetSetsThatHasPartsButNoFiles()
@@ -357,6 +403,11 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="identifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="file">The file that has all parts. Needs to be a zip file.</param>
     /// <returns>200 if successfull, 404 if not found, 500 if something bad happens</returns>
+    /// <response code="200">Parts were uploaded successfully</response>
+    /// <response code="404">Set not found</response>
+    /// <response code="409">A part in the zip file is already assigned to the set</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpPost("sets/{identifier}")]
     public async Task<IActionResult> UploadPartsForSets(string identifier, IFormFile file)
@@ -378,6 +429,11 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="partIdentifier">Name of the part to add</param>
     /// <param name="file">The PDF file for the part</param>
     /// <returns>200 if successfull, 404 if not found, 500 if something bad happens</returns>
+    /// <response code="200">Part content was added successfully</response>
+    /// <response code="404">Set or part not found</response>
+    /// <response code="409">The part is already added to the set</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpPost("sets/{setIdentifier}/parts/{partIdentifier}/content")]
     [MapToApiVersion("1.0")]
@@ -396,6 +452,12 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="partIdentifier">Name of the part to add</param>
     /// <returns>200 if successfull, 404 if not found, 500 if something bad happens</returns>
+    /// <response code="200">Part content was added successfully</response>
+    /// <response code="400">If the uploaded file is missing or invalid</response>
+    /// <response code="404">Set or part not found</response>
+    /// <response code="409">The part is already added to the set</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [DisableFormValueModelBinding]
     [RequestSizeLimit(MaxFileSize)]
@@ -424,6 +486,10 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="partIdentifier">Name of the part to add</param>
     /// <returns>204 if successfull, 404 if not found, 500 if something bad happens</returns>
+    /// <response code="204">Part content and relationship were deleted successfully</response>
+    /// <response code="404">The relationship between the set and part was not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpDelete("sets/{setIdentifier}/parts/{partIdentifier}")]
     public async Task<ActionResult> DeletePart(string setIdentifier, string partIdentifier)
@@ -439,6 +505,11 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// </summary>
     /// <param name="request">Information about the new set</param>
     /// <returns>200 if ok, 500 if something bad happens</returns>
+    /// <response code="200">The newly created set</response>
+    /// <response code="400">If provided input is invalid. Should include a body with ProblemDetails-formatted errors.</response>
+    /// <response code="409">The requested archive number is already in use</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Produces("application/json", Type = typeof(ApiSet))]
     [Authorize(AuthPolicy.Admin)]
     [HttpPost("sets")]
@@ -462,6 +533,10 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// </summary>
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <returns>200 if ok, 404 if not found, 500 if something bad happens</returns>
+    /// <response code="200">Set was deleted successfully</response>
+    /// <response code="404">Set not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpDelete("sets/{setIdentifier}")]
     public async Task<IActionResult> DeleteSet(string setIdentifier)

--- a/src/SheetMusic.Api/Projects/ProjectsController.cs
+++ b/src/SheetMusic.Api/Projects/ProjectsController.cs
@@ -16,53 +16,95 @@ using System.Threading.Tasks;
 
 namespace SheetMusic.Api.Projects;
 
+/// <summary>
+/// This controller contains endpoints for managing Project resources.
+/// Projects group sheet music sets together, e.g. for a concert or event.
+///
+/// PS! Creating, updating and deleting projects require Administrator privileges.
+/// </summary>
 [Authorize]
 [ApiController]
 public class ProjectsController(IMediator mediator) : ControllerBase
 {
+    /// <summary>
+    /// Gets a list of all projects. OData filtering is supported, e.g. $filter=name eq 'Christmas concert'.
+    /// </summary>
+    /// <param name="query">The OData query parameters specified</param>
+    /// <response code="200">A list of projects matching filter, or all projects. Empty list if no matching results</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [HttpGet("projects")]
-    public async Task<IActionResult> GetProjects([FromQuery] ODataQueryParams? query)
+    public async Task<ActionResult<List<ApiProject>>> GetProjects([FromQuery] ODataQueryParams? query)
     {
         var projects = await mediator.Send(new GetProjectCollection(query));
 
-        return new OkObjectResult(projects.Select(p => new ApiProject(p)));
+        return projects.Select(p => new ApiProject(p)).ToList();
     }
 
+    /// <summary>
+    /// Gets details about the project identified by <paramref name="projectIdentifier"/>.
+    /// </summary>
+    /// <param name="projectIdentifier">A value uniquely identifying the project. Either guid or name</param>
+    /// <response code="200">The project matching the identifier</response>
+    /// <response code="404">Project not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [HttpGet("projects/{projectIdentifier}")]
-    public async Task<IActionResult> GetProject(string projectIdentifier)
+    public async Task<ActionResult<ApiProject>> GetProject(string projectIdentifier)
     {
         var project = await mediator.Send(new GetProject(projectIdentifier));
 
-        return new OkObjectResult(new ApiProject(project));
+        return new ApiProject(project);
     }
 
+    /// <summary>
+    /// Gets the sets assigned to the project identified by <paramref name="projectIdentifier"/>.
+    /// </summary>
+    /// <param name="projectIdentifier">A value uniquely identifying the project. Either guid or name</param>
+    /// <response code="200">List of sets assigned to the project</response>
+    /// <response code="404">Project not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
     [HttpGet("projects/{projectIdentifier}/sets")]
-
-    public async Task<IActionResult> GetSetsForProject(string projectIdentifier)
+    public async Task<ActionResult<List<ApiSet>>> GetSetsForProject(string projectIdentifier)
     {
         var project = await mediator.Send(new GetProject(projectIdentifier));
         var sets = await mediator.Send(new GetSetsForProject(project.Id));
 
-        return new OkObjectResult(sets.Select(s => new ApiSet(s)));
+        return sets.Select(s => new ApiSet(s)).ToList();
     }
 
+    /// <summary>
+    /// Adds a new project.
+    /// Requires Administrator privileges.
+    /// </summary>
+    /// <param name="request">Details about the new project</param>
+    /// <response code="200">Details about the newly created project</response>
+    /// <response code="400">If provided input is invalid. Should include a body with ProblemDetails-formatted errors.</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpPost("projects")]
-    public async Task<IActionResult> CreateNewProject([FromBody] NewProjectRequest request)
+    public async Task<ActionResult<ApiProject>> CreateNewProject([FromBody] NewProjectRequest request)
     {
         var project = await mediator.Send(new AddProject(request));
 
-        return new OkObjectResult(new ApiProject(project));
+        return new ApiProject(project);
     }
 
     /// <summary>
     /// Assigns the given sets to a project. The order of <see cref="SetCollectionRequest.SetIdentifiers"/> determines
     /// the sort order of those sets - sets already assigned to the project are moved to match their position in the
     /// list, so this endpoint also covers reordering the sets currently assigned to a project.
+    /// Requires Administrator privileges.
     /// </summary>
+    /// <param name="projectIdentifier">A value uniquely identifying the project. Either guid or name</param>
+    /// <param name="request">The identifiers (guid, archive number or title) of the sets to assign, in the desired order</param>
+    /// <response code="201">The updated list of sets assigned to the project</response>
+    /// <response code="400">If provided input is invalid. Should include a body with ProblemDetails-formatted errors.</response>
+    /// <response code="404">Project not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpPost("projects/{projectIdentifier}/sets")]
-    public async Task<IActionResult> AssignSetToProject(string projectIdentifier, [FromBody] SetCollectionRequest request)
+    public async Task<ActionResult<List<ApiSet>>> AssignSetToProject(string projectIdentifier, [FromBody] SetCollectionRequest request)
     {
         var project = await mediator.Send(new GetProject(projectIdentifier));
 
@@ -84,9 +126,20 @@ public class ProjectsController(IMediator mediator) : ControllerBase
         return new CreatedResult($"projects/{projectIdentifier}/sets", setsForProject.Select(s => new ApiSet(s)));
     }
 
+    /// <summary>
+    /// Removes the given sets from a project.
+    /// Requires Administrator privileges.
+    /// </summary>
+    /// <param name="projectIdentifier">A value uniquely identifying the project. Either guid or name</param>
+    /// <param name="request">The identifiers (guid, archive number or title) of the sets to unassign</param>
+    /// <response code="200">The updated list of sets assigned to the project</response>
+    /// <response code="400">If provided input is invalid. Should include a body with ProblemDetails-formatted errors.</response>
+    /// <response code="404">Project not found, or one of the sets is not assigned to the project</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpDelete("projects/{projectIdentifier}/sets/")]
-    public async Task<IActionResult> UnassignSetFromProject(string projectIdentifier, [FromBody] SetCollectionRequest request)
+    public async Task<ActionResult<List<ApiSet>>> UnassignSetFromProject(string projectIdentifier, [FromBody] SetCollectionRequest request)
     {
         var project = await mediator.Send(new GetProject(projectIdentifier));
 
@@ -101,9 +154,17 @@ public class ProjectsController(IMediator mediator) : ControllerBase
 
         var setsForProject = await mediator.Send(new GetSetsForProject(project.Id));
 
-        return new OkObjectResult(setsForProject.Select(s => new ApiSet(s)));
+        return setsForProject.Select(s => new ApiSet(s)).ToList();
     }
 
+    /// <summary>
+    /// Deletes the project identified by <paramref name="projectIdentifier"/>.
+    /// </summary>
+    /// <param name="projectIdentifier">A value uniquely identifying the project. Either guid or name</param>
+    /// <response code="204">Project was deleted successfully</response>
+    /// <response code="404">Project not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpDelete("projects/{projectIdentifier}")]
     public async Task<ActionResult> DeleteProject(string projectIdentifier)
@@ -113,13 +174,24 @@ public class ProjectsController(IMediator mediator) : ControllerBase
         return NoContent();
     }
 
+    /// <summary>
+    /// Updates the project identified by <paramref name="projectIdentifier"/>. PS! Provide all values, those not provided will be set to null.
+    /// Requires Administrator privileges.
+    /// </summary>
+    /// <param name="projectIdentifier">A value uniquely identifying the project. Either guid or name</param>
+    /// <param name="request">Updated details for the project</param>
+    /// <response code="200">The updated project</response>
+    /// <response code="400">If provided input is invalid. Should include a body with ProblemDetails-formatted errors.</response>
+    /// <response code="404">Project not found</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpPut("projects/{projectIdentifier}")]
-    public async Task<IActionResult> UpdateProject(string projectIdentifier, UpdateProjectRequest request)
+    public async Task<ActionResult<ApiProject>> UpdateProject(string projectIdentifier, UpdateProjectRequest request)
     {
         await mediator.Send(new UpdateProjectMetadata(projectIdentifier, request));
         var project = await mediator.Send(new GetProject(projectIdentifier));
 
-        return new OkObjectResult(new ApiProject(project));
+        return new ApiProject(project);
     }
 }

--- a/src/SheetMusic.Api/Users/UsersController.cs
+++ b/src/SheetMusic.Api/Users/UsersController.cs
@@ -35,6 +35,9 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Authenticate using Identity and receive a JWT token.
     /// </summary>
+    /// <param name="request">The username and password to authenticate with</param>
+    /// <response code="200">The access token</response>
+    /// <response code="400">Username or password is incorrect</response>
     [AllowAnonymous]
     [EnableRateLimiting(RateLimitPolicies.Token)]
     [ProducesResponseType(typeof(ApiAccessTokens), (int)HttpStatusCode.OK)]
@@ -80,6 +83,9 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Register a new user. User is created as inactive and must be activated by an admin.
     /// </summary>
+    /// <param name="request">Details about the new user</param>
+    /// <response code="201">Details about the newly created user</response>
+    /// <response code="400">If provided input is invalid, e.g. weak password</response>
     [AllowAnonymous]
     [HttpPost("users/register")]
     public async Task<IActionResult> RegisterAsync([FromBody] UserRequest request)
@@ -106,6 +112,13 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Update a user's password. Admins can update any user.
     /// </summary>
+    /// <param name="identifier">The guid of the user to update</param>
+    /// <param name="request">The new password</param>
+    /// <response code="200">Password was updated successfully</response>
+    /// <response code="400">Unable to identify the authenticated user</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. Only the user themselves or an Administrator can update the password</response>
+    /// <response code="404">User not found</response>
     [HttpPut("users/{identifier}")]
     public async Task<IActionResult> UpdateUser(Guid identifier, [FromBody] UpdateUserRequest request)
     {
@@ -134,6 +147,9 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Get all users. Admin only.
     /// </summary>
+    /// <response code="200">A list of all users</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpGet("users")]
     public async Task<IActionResult> GetAll()
@@ -146,6 +162,12 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Get a user by ID or "me" for the current user. Admins can view any user; other users may only view themselves.
     /// </summary>
+    /// <param name="identifier">The guid of the user, or "me" for the current user</param>
+    /// <response code="200">The user details, including assigned roles</response>
+    /// <response code="400">Identifier could not be parsed, or the authenticated user could not be identified</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. Only the user themselves or an Administrator can view this user</response>
+    /// <response code="404">User not found</response>
     [HttpGet("users/{identifier}")]
     public async Task<IActionResult> GetByIdAsync(string identifier)
     {
@@ -177,6 +199,12 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Activate a user, allowing them to log in. Admin only.
     /// </summary>
+    /// <param name="id">The guid of the user to activate</param>
+    /// <response code="200">User was activated successfully</response>
+    /// <response code="400">The identity operation failed</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
+    /// <response code="404">User not found</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpPut("users/{id}/activate")]
     public async Task<IActionResult> ActivateUserAsync(Guid id)
@@ -188,6 +216,12 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Deactivate a user, preventing them from logging in. Admin only.
     /// </summary>
+    /// <param name="id">The guid of the user to deactivate</param>
+    /// <response code="200">User was deactivated successfully</response>
+    /// <response code="400">The identity operation failed</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
+    /// <response code="404">User not found</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpPut("users/{id}/deactivate")]
     public async Task<IActionResult> DeactivateUserAsync(Guid id)
@@ -199,6 +233,13 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Assign a role to a user. Admin only.
     /// </summary>
+    /// <param name="id">The guid of the user to assign the role to</param>
+    /// <param name="request">The name of the role to assign</param>
+    /// <response code="200">Role was assigned successfully</response>
+    /// <response code="400">The identity operation failed</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
+    /// <response code="404">User or role not found</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpPut("users/{id}/roles")]
     public async Task<IActionResult> AssignRoleAsync(Guid id, [FromBody] AssignRoleRequest request)
@@ -210,6 +251,13 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Remove a role from a user. Admin only.
     /// </summary>
+    /// <param name="id">The guid of the user to remove the role from</param>
+    /// <param name="roleName">The name of the role to remove</param>
+    /// <response code="204">Role was removed successfully</response>
+    /// <response code="400">The identity operation failed</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
+    /// <response code="404">User not found</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpDelete("users/{id}/roles/{roleName}")]
     public async Task<IActionResult> RemoveRoleAsync(Guid id, string roleName)
@@ -221,6 +269,13 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Delete a user. Defaults to a soft delete (deactivation). Pass <paramref name="hardDelete"/>=true to permanently remove the user. Admin only.
     /// </summary>
+    /// <param name="id">The guid of the user to delete</param>
+    /// <param name="hardDelete">If true, permanently removes the user instead of deactivating it</param>
+    /// <response code="204">User was deleted successfully</response>
+    /// <response code="400">The identity operation failed</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
+    /// <response code="404">User not found</response>
     [Authorize(AuthPolicy.Admin)]
     [HttpDelete("users/{id}")]
     public async Task<IActionResult> DeleteUserAsync(Guid id, [FromQuery] bool hardDelete = false)
@@ -233,6 +288,8 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// Request a password reset email. Always returns 200 to prevent user enumeration.
     /// Rate limited per client IP to prevent abuse of the outbound email flow.
     /// </summary>
+    /// <param name="request">The email address of the user requesting a reset</param>
+    /// <response code="200">Request was accepted (regardless of whether the email is registered)</response>
     [AllowAnonymous]
     [EnableRateLimiting(RateLimitPolicies.ForgotPassword)]
     [HttpPost("users/forgot-password")]
@@ -245,6 +302,9 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <summary>
     /// Reset a user's password using a token received via email.
     /// </summary>
+    /// <param name="request">The email, reset token and new password</param>
+    /// <response code="200">Password was reset successfully</response>
+    /// <response code="400">The reset token is invalid or expired</response>
     [AllowAnonymous]
     [HttpPost("users/reset-password")]
     public async Task<IActionResult> ResetPasswordAsync([FromBody] ResetPasswordRequest request)

--- a/src/SheetMusic.Api/Users/UsersV1Controller.cs
+++ b/src/SheetMusic.Api/Users/UsersV1Controller.cs
@@ -31,6 +31,9 @@ public class UsersV1Controller(IUserRepository userRepository, IConfiguration co
     /// <summary>
     /// Authenticate using legacy HMAC password hash and receive a JWT token.
     /// </summary>
+    /// <param name="request">The username and password to authenticate with</param>
+    /// <response code="200">The access token</response>
+    /// <response code="400">Username or password is incorrect</response>
     [AllowAnonymous]
     [EnableRateLimiting(RateLimitPolicies.Token)]
     [ProducesResponseType(typeof(ApiAccessTokens), (int)HttpStatusCode.OK)]
@@ -69,6 +72,9 @@ public class UsersV1Controller(IUserRepository userRepository, IConfiguration co
     /// <summary>
     /// Register a new user using legacy password hashing.
     /// </summary>
+    /// <param name="request">Details about the new user</param>
+    /// <response code="201">Details about the newly created user</response>
+    /// <response code="409">A user with the same email already exists</response>
     [AllowAnonymous]
     [HttpPost("users/register")]
     public async Task<IActionResult> RegisterAsync([FromBody] UserRequest request)
@@ -97,6 +103,13 @@ public class UsersV1Controller(IUserRepository userRepository, IConfiguration co
     /// <summary>
     /// Update a user's password using legacy password hashing.
     /// </summary>
+    /// <param name="identifier">The guid of the user to update</param>
+    /// <param name="request">The new password</param>
+    /// <response code="200">Password was updated successfully</response>
+    /// <response code="400">Unable to identify the authenticated user, or the target user is not yourself and you are not admin</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
+    /// <response code="404">User not found</response>
     [HttpPut("users/{identifier}")]
     public async Task<IActionResult> UpdateUser(Guid identifier, [FromBody] UpdateUserRequest request)
     {
@@ -122,6 +135,9 @@ public class UsersV1Controller(IUserRepository userRepository, IConfiguration co
     /// <summary>
     /// Get all users.
     /// </summary>
+    /// <response code="200">A list of all users</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [HttpGet("users")]
     public IActionResult GetAll()
     {
@@ -136,6 +152,12 @@ public class UsersV1Controller(IUserRepository userRepository, IConfiguration co
     /// <summary>
     /// Get a user by ID or "me" for the current user.
     /// </summary>
+    /// <param name="identifier">The guid of the user, or "me" for the current user</param>
+    /// <response code="200">The user matching the identifier</response>
+    /// <response code="400">Identifier could not be parsed</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
+    /// <response code="404">User not found</response>
     [HttpGet("users/{identifier}")]
     public async Task<IActionResult> GetByIdAsync(string identifier)
     {


### PR DESCRIPTION
## Summary

Bring every REST endpoint up to the documentation standard already set by `PartsController` and `CategoriesController`, per #218.

## Changes

- `ProjectsController`: controller-level `<summary>`, per-action `<summary>`/`<param>`/`<response>` tags, and converted actions from `IActionResult` to `ActionResult<T>` so Swagger can infer response schemas.
- `SheetMusicController`: controller-level `<summary>` and missing `<response>` tags added to every action (400/401/403/404/409 as applicable).
- `UsersController` / `UsersV1Controller`: missing `<param>` and `<response>` tags added to every action.
- `copilot-instructions.md`: documented the REST endpoint documentation standard.
- Added `.vscode/settings.json` commit reminder instructions.

`PartsController` and `CategoriesController` were left unchanged since they were already the reference standard.

## Acceptance criteria

- [x] Every public action across `ProjectsController`, `SheetMusicController`, `PartsController`, `CategoriesController`, `UsersController` and `UsersV1Controller` has a `<summary>`, `<param>` tags and `<response>` tags.
- [x] `ProjectsController` actions return `ActionResult<T>` with the correct view model type.
- [x] No new build warnings from missing XML comments (verified via `dotnet build`).

Closes #218
