### PR TITLE
fix(parts): support $expand=aliases on GET /parts

### DIFF
--- a/src/SheetMusic.Api.Test/Parts/PartTests.cs
+++ b/src/SheetMusic.Api.Test/Parts/PartTests.cs
@@ -318,6 +318,53 @@ public class PartTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
+    public async Task GetPartList_WithExpandAliases_ShouldIncludeAliases()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var part = await new PartDataBuilder(adminClient).ProvisionSinglePartAsync();
+        var alias = $"expand-alias-{Guid.NewGuid():N}";
+
+        await adminClient.PostAsJsonAsync($"parts/{part.Id}/aliases?alias={alias}", new { });
+
+        var response = await adminClient.GetAsync($"parts?$filter={Uri.EscapeDataString($"name eq '{part.Name}'")}&$expand=aliases");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var parts = await response.Content.ReadFromJsonAsync<List<ApiPart>>(JsonDefaults.Options);
+        parts.Should().ContainSingle();
+        parts![0].Aliases.Should().Contain(alias);
+    }
+
+    [Fact]
+    public async Task GetPartList_WithoutExpand_ShouldNotIncludeAliases()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var part = await new PartDataBuilder(adminClient).ProvisionSinglePartAsync();
+        var alias = $"no-expand-alias-{Guid.NewGuid():N}";
+
+        await adminClient.PostAsJsonAsync($"parts/{part.Id}/aliases?alias={alias}", new { });
+
+        var response = await adminClient.GetAsync($"parts?$filter={Uri.EscapeDataString($"name eq '{part.Name}'")}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var parts = await response.Content.ReadFromJsonAsync<List<ApiPart>>(JsonDefaults.Options);
+        parts.Should().ContainSingle();
+        parts![0].Aliases.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("$expand=parts")]
+    [InlineData("$expand=aliases,unknown")]
+    [InlineData("$expand=aliases,")]
+    [InlineData("$expand=")]
+    public async Task GetPartList_WithInvalidExpand_ShouldReturnBadRequest(string clause)
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+
+        var response = await adminClient.GetAsync($"parts?{clause}");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task GetPart_ShouldReturn404_WhenPartDoesNotExist()
     {
         var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);

--- a/src/SheetMusic.Api/Parts/PartsController.cs
+++ b/src/SheetMusic.Api/Parts/PartsController.cs
@@ -1,12 +1,14 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using SheetMusic.Api.Errors;
 using SheetMusic.Api.OData.MVC;
 using SheetMusic.Api.Parts.Commands;
 using SheetMusic.Api.Parts.Errors;
 using SheetMusic.Api.Parts.Queries;
 using SheetMusic.Api.Parts.RequestModels;
 using SheetMusic.Api.Parts.ViewModels;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -24,6 +26,7 @@ namespace SheetMusic.Api.Parts;
 [Produces("application/json")]
 public class PartsController(IMediator mediator) : ControllerBase
 {
+    private const string SupportedPartExpand = "aliases";
 
     /// <summary>
     /// Rebuild the part index manually. 
@@ -44,15 +47,24 @@ public class PartsController(IMediator mediator) : ControllerBase
 
     /// <summary>
     /// Gets a list of all Parts. OData filtering is supported, e.g. $filter=name eq 'partitur'.
+    /// Use $expand=aliases to include the enabled aliases of each part.
     /// Requires Administrator privileges.
     /// </summary>
     /// <param name="queryParams">The OData query paramateres specified</param>
     /// <response code="200">A list of parts matching filter, or all parts. Empty list if no matching results</response>
+    /// <response code="400">If an unsupported $expand value is provided</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
     /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
     [HttpGet("parts")]
     public async Task<ActionResult<List<ApiPart>>> GetPartList([FromQuery] ODataQueryParams queryParams)
     {
+        var unsupportedExpands = queryParams.Expand
+            .Where(e => !string.Equals(e, SupportedPartExpand, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (unsupportedExpands.Count > 0)
+            throw new InvalidQueryParametersError($"Unsupported $expand value(s): {string.Join(", ", unsupportedExpands)}. Supported values: {SupportedPartExpand}");
+
         var results = await mediator.Send(new GetPartCollection(queryParams));
         var apiModels = results.Select(p => new ApiPart(p));
 

--- a/src/SheetMusic.Api/Parts/Queries/GetPartCollection.cs
+++ b/src/SheetMusic.Api/Parts/Queries/GetPartCollection.cs
@@ -5,7 +5,9 @@ using SheetMusic.Api.OData;
 using SheetMusic.Api.OData.Extensions;
 using SheetMusic.Api.OData.MVC;
 using SheetMusic.Api.Database.Entities;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,6 +22,12 @@ public class GetPartCollection(ODataQueryParams queryParams) : IRequest<List<Mus
         public async Task<List<MusicPart>> Handle(GetPartCollection request, CancellationToken cancellationToken)
         {
             var query = db.MusicParts.AsQueryable();
+
+            if (request.QueryParams != null &&
+                request.QueryParams.Expand.Any(e => string.Equals(e, "aliases", StringComparison.OrdinalIgnoreCase)))
+            {
+                query = query.Include(p => p.Aliases);
+            }
 
             if (request.QueryParams != null && request.QueryParams.HasFilter)
             {


### PR DESCRIPTION
## Summary

`GET /parts` never returned aliases and silently ignored `$expand`. This makes `$expand=aliases` work and validates the parameter consistently with `GET /sheetmusic/sets`.

## Changes

- `Parts/Queries/GetPartCollection.cs` — `.Include(p => p.Aliases)` when `$expand=aliases` is requested.
- `Parts/PartsController.cs` — validates `$expand` values on `GET /parts`, throwing `InvalidQueryParametersError` (400) for unsupported values; updated XML docs (`$expand` usage and `400` response).
- `SheetMusic.Api.Test/Parts/PartTests.cs` — new tests:
  - aliases returned with `$expand=aliases`
  - aliases empty without `$expand`
  - `400` for `$expand=parts`, `$expand=aliases,unknown`, `$expand=aliases,`, `$expand=`

## Verification

All 40 tests in `PartTests` pass.

Fixes #217
