### PR TITLE
fix(blob-storage): avoid disposing shared BlobServiceClient registration in data protection setup

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -2,7 +2,7 @@
 description: "Fast code reviewer for Sheet Music API. Reviews code against CQRS, MediatR, and project conventions. Use when validating implementations, checking for pattern violations, or reviewing pull requests."
 name: "Code Reviewer"
 tools: [read, search]
-model: GPT-5.4 mini (copilot)
+model: GPT-5.6 Luna (copilot)
 user-invocable: false
 ---
 

--- a/src/SheetMusic.Api.Test/Infrastructure/AzuriteFixture.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/AzuriteFixture.cs
@@ -25,6 +25,8 @@ public class AzuriteFixture : IAsyncLifetime
 
     public Uri BlobEndpoint => new(container.GetBlobEndpoint());
 
+    public string ConnectionString => container.GetConnectionString();
+
     public StorageSharedKeyCredential Credential { get; } =
         new(AzuriteBuilder.AccountName, AzuriteBuilder.AccountKey);
 

--- a/src/SheetMusic.Api.Test/Users/DataProtectionPersistenceTests.cs
+++ b/src/SheetMusic.Api.Test/Users/DataProtectionPersistenceTests.cs
@@ -2,8 +2,11 @@ using Azure.Storage.Blobs;
 using FluentAssertions;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using SheetMusic.Api.BlobStorage;
+using SheetMusic.Api.Configuration;
 using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.TestCollections;
 using System;
@@ -39,6 +42,34 @@ public class DataProtectionPersistenceTests(AzuriteFixture azurite)
         var unprotected = protectorB.Unprotect(protectedPayload);
 
         unprotected.Should().Be("password-reset-token");
+    }
+
+    /// <summary>
+    /// Regression test for the production bug where <see cref="IServiceCollectionExtensions.AddSheetMusicDataProtection"/>
+    /// used to build a second, throwaway <see cref="IServiceProvider"/> to eagerly resolve a
+    /// <see cref="BlobServiceClient"/>, then dispose it - which also disposed Azure Client Factory
+    /// registration state shared with the app's real provider, causing every later
+    /// <see cref="BlobServiceClient"/> resolution to fail with <see cref="ObjectDisposedException"/>
+    /// ("ClientRegistration"). Registers a real Azure Client Factory <see cref="BlobServiceClient"/> -
+    /// the same registration shape <c>AddAzureBlobServiceClient</c> produces - runs it through
+    /// <see cref="IServiceCollectionExtensions.AddSheetMusicDataProtection"/>, forces the lazy
+    /// <see cref="KeyManagementOptions"/> configuration to materialize, and then confirms the same
+    /// provider can still resolve a working <see cref="BlobServiceClient"/> afterwards.
+    /// </summary>
+    [Fact]
+    public void AddSheetMusicDataProtection_DoesNotBreakLaterBlobServiceClientResolution()
+    {
+        var services = new ServiceCollection();
+        services.AddAzureClients(clientBuilder => clientBuilder.AddBlobServiceClient(azurite.ConnectionString));
+        services.AddSheetMusicDataProtection("SheetMusic.Api.Test");
+
+        using var provider = services.BuildServiceProvider();
+
+        var keyManagementOptions = provider.GetRequiredService<IOptions<KeyManagementOptions>>().Value;
+        keyManagementOptions.XmlRepository.Should().BeOfType<AzureBlobXmlRepository>();
+
+        var resolveAfterOptions = () => provider.GetRequiredService<BlobServiceClient>();
+        resolveAfterOptions.Should().NotThrow();
     }
 
     private static IDataProtector BuildProtector(BlobContainerClient container)

--- a/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
+++ b/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
@@ -60,30 +60,37 @@ public static class IServiceCollectionExtensions
     /// BlobStorage/AzureBlobXmlRepository.cs for why a small custom <see cref="IXmlRepository"/> is used
     /// instead of Microsoft's official (legacy-SDK-only) DataProtection.AzureStorage package.
     ///
-    /// Resolving the <see cref="BlobServiceClient"/> requires a throwaway service provider built from
-    /// the services registered so far - this must therefore be called after the app's
-    /// <see cref="BlobServiceClient"/> registration (e.g. <c>AddAzureBlobServiceClient</c>). Guarded:
-    /// hosts with no blob storage configured at all (e.g. the WebApplicationFactory-based test host,
-    /// which doesn't run through the AppHost) fall back to Data Protection's default local key storage
-    /// instead of failing application startup - matching the historical, storage-optional behaviour.
+    /// The <see cref="BlobServiceClient"/> is resolved lazily from the app's own service provider, via
+    /// DI-injected options configuration, rather than by building a second, throwaway
+    /// <see cref="IServiceProvider"/> here. The Azure Client Factory registration added by
+    /// <c>AddAzureBlobServiceClient</c> caches client state in a singleton that is shared across every
+    /// provider built from this same <see cref="IServiceCollection"/> - building and disposing an extra
+    /// provider to eagerly grab a <see cref="BlobServiceClient"/> disposed that shared state out from
+    /// under the app's real provider, causing an intermittent <see cref="ObjectDisposedException"/>
+    /// ("ClientRegistration") the first time any later request resolved a <see cref="BlobServiceClient"/>
+    /// (issue: 500 on GetPartsForSet and similar). Guarded: hosts with no blob storage configured at all
+    /// (e.g. the WebApplicationFactory-based test host, which doesn't run through the AppHost and where
+    /// <see cref="BlobServiceClient"/> is registered but throws <see cref="InvalidOperationException"/>
+    /// on resolution) fall back to Data Protection's default local key storage instead of failing
+    /// application startup - matching the historical, storage-optional behaviour.
     /// </summary>
     public static IServiceCollection AddSheetMusicDataProtection(this IServiceCollection services, string applicationName)
     {
         services.AddDataProtection().SetApplicationName(applicationName);
 
-        try
+        services.AddOptions<KeyManagementOptions>().Configure<IServiceProvider>((options, serviceProvider) =>
         {
-            using var blobServiceProvider = services.BuildServiceProvider();
-            var blobServiceClient = blobServiceProvider.GetRequiredService<BlobServiceClient>();
-            var keyRingContainer = blobServiceClient.GetBlobContainerClient("data-protection-keys");
-
-            services.Configure<KeyManagementOptions>(options =>
-                options.XmlRepository = new AzureBlobXmlRepository(keyRingContainer, "keys.xml"));
-        }
-        catch (InvalidOperationException)
-        {
-            // No blob storage configured for this host; Data Protection uses its default key storage.
-        }
+            try
+            {
+                var blobServiceClient = serviceProvider.GetRequiredService<BlobServiceClient>();
+                var keyRingContainer = blobServiceClient.GetBlobContainerClient("data-protection-keys");
+                options.XmlRepository = new AzureBlobXmlRepository(keyRingContainer, "keys.xml");
+            }
+            catch (InvalidOperationException)
+            {
+                // No blob storage configured for this host; Data Protection uses its default key storage.
+            }
+        });
 
         return services;
     }


### PR DESCRIPTION
## Problem

Production logs showed intermittent 500s on requests that resolve `BlobServiceClient` (e.g. `GetPartsForSet`):

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'ClientRegistration'.
   at Microsoft.Extensions.Azure.ClientRegistration`1.TryGetCachedClientOrThrow(TClient& cachedClient)
```

`AddSheetMusicDataProtection` built a throwaway `IServiceProvider` (`services.BuildServiceProvider()`) purely to eagerly resolve a `BlobServiceClient` for the Data Protection key ring, then disposed it via `using`. The Azure Client Factory registration added by `AddAzureBlobServiceClient` caches client state in a singleton that is shared across every provider built from the same `IServiceCollection` - disposing the throwaway provider also disposed that shared state, breaking every later `BlobServiceClient` resolution from the app's real provider.

## Fix

Resolve the `BlobServiceClient` lazily from the app's real provider instead, via `services.AddOptions<KeyManagementOptions>().Configure<IServiceProvider>(...)`, with a narrow try/catch around `GetRequiredService<BlobServiceClient>()` to preserve the existing fallback to local key storage on hosts without blob storage configured (e.g. the WebApplicationFactory-based test host).

## Testing

- Added `AddSheetMusicDataProtection_DoesNotBreakLaterBlobServiceClientResolution`, which registers a real Azure Client Factory `BlobServiceClient`, runs it through `AddSheetMusicDataProtection`, forces the lazy options to materialize, and confirms the same provider can still resolve `BlobServiceClient` afterwards - this would have failed against the old implementation.
- Added `AzuriteFixture.ConnectionString` to support the new test.
- Full test suite passes (299 tests).

## Other

- Bumped the Code Reviewer subagent's model.
