### PR TITLE
feat(users): report actionable password requirement errors and expose the policy

### DIFF
--- a/src/SheetMusic.Api.Test/Users/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Users/UserTests.cs
@@ -5,6 +5,9 @@ using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
 using SheetMusic.Api.Test.Infrastructure.TestCollections;
+using SheetMusic.Api.Test.Utility;
+using SheetMusic.Api.Users.Errors;
+using SheetMusic.Api.Users.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -277,7 +280,7 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
-    public async Task V2_RegisterUser_ShouldReturnBadRequest_WhenWeakPassword()
+    public async Task V2_RegisterUser_ShouldReturnRequirementDetails_WhenWeakPassword()
     {
         var client = CreateV2Client();
 
@@ -289,7 +292,41 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
             Password = "short"
         });
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<PasswordProblemResponse>(JsonDefaults.Options);
+        problem.Should().NotBeNull();
+        problem!.Type.Should().Be(nameof(PasswordRequirementsNotMetError));
+        problem.FailedRequirements.Should().Contain("PasswordTooShort");
+        problem.Messages.Should().NotBeNullOrEmpty();
+        problem.Requirements.Should().NotBeNull();
+        problem.Requirements!.MinimumLength.Should().Be(8);
     }
+
+    [Fact]
+    public async Task V2_GetPasswordRequirements_ShouldReturnConfiguredValues()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.GetAsync("users/password-requirements");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var requirements = await response.Content.ReadFromJsonAsync<ApiPasswordRequirements>(JsonDefaults.Options);
+        requirements.Should().NotBeNull();
+        requirements!.MinimumLength.Should().Be(8);
+        requirements.RequireDigit.Should().BeTrue();
+        requirements.RequireUppercase.Should().BeTrue();
+        requirements.RequireLowercase.Should().BeTrue();
+        requirements.RequireNonAlphanumeric.Should().BeFalse();
+    }
+
+    private sealed record PasswordProblemResponse(
+        int? Status,
+        string? Title,
+        string? Type,
+        string? Detail,
+        List<string>? FailedRequirements,
+        List<string>? Messages,
+        ApiPasswordRequirements? Requirements);
 
     [Fact]
     public async Task V2_GetAllUsers_ShouldBeSuccessful_WhenAdmin()
@@ -384,6 +421,42 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
             Password = "HackerPassword1!"
         });
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task V2_UpdateUser_ShouldReturnBadRequest_WhenWeakPassword()
+    {
+        var anonymousClient = CreateV2Client();
+        var email = $"weakupdate-{Guid.NewGuid():N}@user.com";
+        const string originalPassword = "Original123!";
+
+        await anonymousClient.PostAsJsonAsync("users/register", new
+        {
+            Id = Guid.NewGuid(),
+            Name = "Weak Update User",
+            Email = email,
+            Password = originalPassword
+        });
+
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var appUser = await userManager.FindByEmailAsync(email);
+        appUser!.Inactive = false;
+        await userManager.UpdateAsync(appUser);
+
+        var adminClient = CreateV2ClientWithTestToken(TestUser.Administrator);
+        var response = await adminClient.PutAsJsonAsync($"users/{appUser.Id}", new { Password = "weak" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<PasswordProblemResponse>(JsonDefaults.Options);
+        problem.Should().NotBeNull();
+        problem!.Type.Should().Be(nameof(PasswordRequirementsNotMetError));
+
+        // The bug this guards against: UpdateUser used to discard the IdentityResult and return 200,
+        // silently leaving the password unchanged while telling the caller it had been updated.
+        var loginResponse = await anonymousClient.PostAsync("token", BuildLoginForm(email, originalPassword));
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // --- User management: activate / deactivate / roles / delete ---
@@ -723,18 +796,69 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
-    public async Task ResetPassword_ShouldReturn400_WhenPasswordIsTooWeak()
+    public async Task V2_ResetPassword_ShouldReturnPasswordError_WhenWeakPassword()
     {
         var client = CreateV2Client();
+        factory.FakeEmail.Clear();
 
+        // Register a dedicated user for this test to avoid mutating shared test users
+        var email = $"resetweak-{Guid.NewGuid():N}@user.com";
+
+        await client.PostAsJsonAsync("users/register", new
+        {
+            Id = Guid.NewGuid(),
+            Name = "Reset Weak User",
+            Email = email,
+            Password = "Original123!"
+        });
+
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var appUser = await userManager.FindByEmailAsync(email);
+        appUser!.Inactive = false;
+        await userManager.UpdateAsync(appUser);
+
+        // Request a valid reset token
+        await client.PostAsJsonAsync("users/forgot-password", new { Email = email });
+        factory.FakeEmail.SentEmails.Should().HaveCount(1);
+        var token = factory.FakeEmail.SentEmails[0].ResetToken;
+
+        // A valid token plus a weak password must be reported as a password error, not an expired/invalid link
         var response = await client.PostAsJsonAsync("users/reset-password", new
         {
-            Email = TestUser.Testesen.Email,
-            Token = "sometoken",
+            Email = email,
+            Token = token,
             NewPassword = "weak"
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<PasswordProblemResponse>(JsonDefaults.Options);
+        problem.Should().NotBeNull();
+        problem!.Type.Should().Be(nameof(PasswordRequirementsNotMetError));
+        problem.FailedRequirements.Should().Contain("PasswordTooShort");
+    }
+
+    [Fact]
+    public async Task V2_ResetPassword_ShouldReturnGenericError_WhenUnknownEmail()
+    {
+        var client = CreateV2Client();
+
+        // Guards the anti-enumeration behaviour: an unknown email must still get the generic
+        // invalid-token error, never a password-specific one.
+        var response = await client.PostAsJsonAsync("users/reset-password", new
+        {
+            Email = $"unknown-reset-{Guid.NewGuid():N}@nobody.com",
+            Token = "irrelevant-token",
+            NewPassword = "StrongPassword123!"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<PasswordProblemResponse>(JsonDefaults.Options);
+        problem.Should().NotBeNull();
+        problem!.Type.Should().Be(nameof(InvalidPasswordResetTokenError));
+        problem.FailedRequirements.Should().BeNull();
     }
 
     // --- Account lockout ---

--- a/src/SheetMusic.Api/Errors/ErrorHandlerMiddleware.cs
+++ b/src/SheetMusic.Api/Errors/ErrorHandlerMiddleware.cs
@@ -10,6 +10,10 @@ namespace SheetMusic.Api.Errors;
 
 public class ErrorHandlerMiddleware(RequestDelegate next, ILogger<ErrorHandlerMiddleware> logger)
 {
+    // Matches the camelCase naming ASP.NET Core MVC uses by default for controller responses, so
+    // manually-serialized error responses (this middleware runs outside the MVC pipeline) look the same.
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
     public async Task Invoke(HttpContext context)
     {
         try
@@ -22,6 +26,12 @@ public class ErrorHandlerMiddleware(RequestDelegate next, ILogger<ErrorHandlerMi
 
             var errorType = eb.GetType().Name;
             var error = new ProblemDetails { Status = (int)eb.StatusCode, Type = errorType, Title = errorType, Detail = eb.Message };
+
+            if (eb.Extensions is not null)
+            {
+                foreach (var (key, value) in eb.Extensions)
+                    error.Extensions[key] = value;
+            }
 
             await WriteProblemDetailsAsync(context, error);
         }
@@ -50,6 +60,6 @@ public class ErrorHandlerMiddleware(RequestDelegate next, ILogger<ErrorHandlerMi
         context.Response.Clear();
         context.Response.StatusCode = error.Status ?? (int)HttpStatusCode.InternalServerError;
         context.Response.ContentType = "application/json";
-        await context.Response.WriteAsync(JsonSerializer.Serialize(error));
+        await context.Response.WriteAsync(JsonSerializer.Serialize(error, SerializerOptions));
     }
 }

--- a/src/SheetMusic.Api/Errors/ExceptionBase.cs
+++ b/src/SheetMusic.Api/Errors/ExceptionBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 
 namespace SheetMusic.Api.Errors;
@@ -14,4 +15,11 @@ public class ExceptionBase : Exception
     }
 
     public virtual HttpStatusCode StatusCode => HttpStatusCode.InternalServerError;
+
+    /// <summary>
+    /// Additional machine-readable data to merge into the <c>ProblemDetails</c> response as extension
+    /// members (e.g. <see cref="Users.Errors.PasswordRequirementsNotMetError"/>'s failed requirement
+    /// codes). Null by default, since most errors need only the base ProblemDetails fields.
+    /// </summary>
+    public virtual IDictionary<string, object?>? Extensions => null;
 }

--- a/src/SheetMusic.Api/Users/Commands/ResetPassword.cs
+++ b/src/SheetMusic.Api/Users/Commands/ResetPassword.cs
@@ -1,7 +1,10 @@
 using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Users.Errors;
+using SheetMusic.Api.Users.ViewModels;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,19 +16,32 @@ public class ResetPassword(string email, string token, string newPassword) : IRe
     public string Token { get; } = token;
     public string NewPassword { get; } = newPassword;
 
-    public class Handler(UserManager<ApplicationUser> userManager) : IRequestHandler<ResetPassword>
+    public class Handler(UserManager<ApplicationUser> userManager, IOptions<IdentityOptions> identityOptions) : IRequestHandler<ResetPassword>
     {
         public async Task Handle(ResetPassword request, CancellationToken cancellationToken)
         {
+            // Never distinguish an unknown email from any other failure here - doing so would let a
+            // caller enumerate registered accounts.
             var user = await userManager.FindByEmailAsync(request.Email);
 
             if (user == null)
                 throw new InvalidPasswordResetTokenError();
 
+            // UserManager.ResetPasswordAsync verifies the token via VerifyUserTokenAsync first and
+            // returns an InvalidToken error immediately on failure, so password validators only run
+            // once the token has been accepted. A password error below is therefore unreachable without
+            // a valid, unexpired token.
             var result = await userManager.ResetPasswordAsync(user, request.Token, request.NewPassword);
 
             if (!result.Succeeded)
+            {
+                var passwordErrors = result.Errors.Where(PasswordRequirementsNotMetError.IsPasswordError).ToList();
+
+                if (passwordErrors.Count > 0)
+                    throw new PasswordRequirementsNotMetError(passwordErrors, ApiPasswordRequirements.FromPasswordOptions(identityOptions.Value.Password));
+
                 throw new InvalidPasswordResetTokenError();
+            }
         }
     }
 }

--- a/src/SheetMusic.Api/Users/Errors/PasswordRequirementsNotMetError.cs
+++ b/src/SheetMusic.Api/Users/Errors/PasswordRequirementsNotMetError.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Identity;
+using SheetMusic.Api.Errors;
+using SheetMusic.Api.Users.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace SheetMusic.Api.Users.Errors;
+
+/// <summary>
+/// Thrown when ASP.NET Core Identity rejects a password for not meeting the configured complexity
+/// policy. Carries the failed <see cref="IdentityError.Code"/> values (stable and machine-readable, so
+/// clients can highlight the exact failing rule instead of parsing prose), the corresponding
+/// descriptions for direct display, and the policy itself so a client can render both with one type.
+/// </summary>
+public class PasswordRequirementsNotMetError(IReadOnlyCollection<IdentityError> identityErrors, ApiPasswordRequirements requirements)
+    : ExceptionBase("The provided password does not meet the requirements.")
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+
+    public IReadOnlyList<string> FailedRequirements { get; } = identityErrors.Select(e => e.Code).ToList();
+    public IReadOnlyList<string> Messages { get; } = identityErrors.Select(e => e.Description).ToList();
+    public ApiPasswordRequirements Requirements { get; } = requirements;
+
+    public override IDictionary<string, object?> Extensions => new Dictionary<string, object?>
+    {
+        ["failedRequirements"] = FailedRequirements,
+        ["messages"] = Messages,
+        ["requirements"] = Requirements
+    };
+
+    /// <summary>
+    /// Identity's password validators (see <c>PasswordValidator&lt;TUser&gt;</c>) prefix every
+    /// password-complexity error code with "Password" (e.g. <c>PasswordTooShort</c>,
+    /// <c>PasswordRequiresDigit</c>). Used to separate those from unrelated <see cref="IdentityResult"/>
+    /// failures (e.g. an invalid reset token) so each gets the right error type.
+    /// </summary>
+    public static bool IsPasswordError(IdentityError error) => error.Code?.StartsWith("Password", StringComparison.Ordinal) == true;
+
+    /// <summary>
+    /// Maps a failed <see cref="IdentityResult"/> to the appropriate error: this type when any failure
+    /// is password-complexity related, or the generic <see cref="IdentityOperationError"/> otherwise.
+    /// Shared by every v2 endpoint that runs a password through <see cref="Microsoft.AspNetCore.Identity.UserManager{TUser}"/>
+    /// (register, update, reset), so the mapping itself lives in one place rather than in each caller.
+    /// </summary>
+    public static ExceptionBase FromFailedResult(IdentityResult result, ApiPasswordRequirements requirements)
+    {
+        var passwordErrors = result.Errors.Where(IsPasswordError).ToList();
+
+        return passwordErrors.Count > 0
+            ? new PasswordRequirementsNotMetError(passwordErrors, requirements)
+            : new IdentityOperationError(result.Errors.Select(e => e.Description));
+    }
+}

--- a/src/SheetMusic.Api/Users/Queries/GetPasswordRequirements.cs
+++ b/src/SheetMusic.Api/Users/Queries/GetPasswordRequirements.cs
@@ -1,0 +1,23 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using SheetMusic.Api.Users.ViewModels;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Queries;
+
+/// <summary>
+/// Retrieves the password complexity policy from the configured <see cref="IdentityOptions"/>, so the
+/// advertised policy can never disagree with what <see cref="UserManager{TUser}"/> actually enforces.
+/// </summary>
+public class GetPasswordRequirements : IRequest<ApiPasswordRequirements>
+{
+    public class Handler(IOptions<IdentityOptions> identityOptions) : IRequestHandler<GetPasswordRequirements, ApiPasswordRequirements>
+    {
+        public Task<ApiPasswordRequirements> Handle(GetPasswordRequirements request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(ApiPasswordRequirements.FromPasswordOptions(identityOptions.Value.Password));
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/RequestModels/ResetPasswordRequest.cs
+++ b/src/SheetMusic.Api/Users/RequestModels/ResetPasswordRequest.cs
@@ -14,12 +14,13 @@ public class ResetPasswordRequest
         {
             RuleFor(r => r.Email).NotEmpty().EmailAddress().WithMessage("A valid email address is required.");
             RuleFor(r => r.Token).NotEmpty().WithMessage("Reset token is required.");
-            RuleFor(r => r.NewPassword)
-                .NotEmpty()
-                .MinimumLength(8)
-                .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter.")
-                .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter.")
-                .Matches("[0-9]").WithMessage("Password must contain at least one digit.");
+
+            // Complexity rules are intentionally not duplicated here. Identity's PasswordValidator
+            // (configured via IdentityOptions.Password in Program.cs) is the sole enforcement point for
+            // all v2 password paths - see ResetPassword.Handler, which maps its failures to
+            // PasswordRequirementsNotMetError. Re-adding rules here would run before the handler (this
+            // validator runs via FluentValidation auto-validation) and shadow that error path entirely.
+            RuleFor(r => r.NewPassword).NotEmpty().WithMessage("New password is required.");
         }
     }
 }

--- a/src/SheetMusic.Api/Users/UsersController.cs
+++ b/src/SheetMusic.Api/Users/UsersController.cs
@@ -5,12 +5,14 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using SheetMusic.Api.Configuration;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Errors;
 using SheetMusic.Api.Users.Authorization;
 using SheetMusic.Api.Users.Commands;
+using SheetMusic.Api.Users.Errors;
 using SheetMusic.Api.Users.Queries;
 using SheetMusic.Api.Users.RequestModels;
 using SheetMusic.Api.Users.ViewModels;
@@ -30,7 +32,7 @@ namespace SheetMusic.Api.Users;
 [ApiVersion("2.0")]
 [Authorize]
 [ApiController]
-public class UsersController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, IConfiguration configuration, IMediator mediator) : ControllerBase
+public class UsersController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, IConfiguration configuration, IMediator mediator, IOptions<IdentityOptions> identityOptions) : ControllerBase
 {
     /// <summary>
     /// Authenticate using Identity and receive a JWT token.
@@ -85,7 +87,8 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// </summary>
     /// <param name="request">Details about the new user</param>
     /// <response code="201">Details about the newly created user</response>
-    /// <response code="400">If provided input is invalid, e.g. weak password</response>
+    /// <response code="400">If provided input is invalid. A password that does not meet the requirements
+    /// returned by <c>GET users/password-requirements</c> produces a <see cref="PasswordRequirementsNotMetError"/></response>
     [AllowAnonymous]
     [HttpPost("users/register")]
     public async Task<IActionResult> RegisterAsync([FromBody] UserRequest request)
@@ -102,7 +105,7 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
         var result = await userManager.CreateAsync(user, request.Password);
 
         if (!result.Succeeded)
-            return BadRequest(new { errors = result.Errors.Select(e => e.Description) });
+            throw PasswordRequirementsNotMetError.FromFailedResult(result, ApiPasswordRequirements.FromPasswordOptions(identityOptions.Value.Password));
 
         await userManager.AddToRoleAsync(user, "Reader");
 
@@ -115,7 +118,9 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
     /// <param name="identifier">The guid of the user to update</param>
     /// <param name="request">The new password</param>
     /// <response code="200">Password was updated successfully</response>
-    /// <response code="400">Unable to identify the authenticated user</response>
+    /// <response code="400">Unable to identify the authenticated user, or the new password does not
+    /// meet the requirements returned by <c>GET users/password-requirements</c> (<see cref="PasswordRequirementsNotMetError"/>).
+    /// The existing password remains valid in that case.</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
     /// <response code="403">Forbidden. Only the user themselves or an Administrator can update the password</response>
     /// <response code="404">User not found</response>
@@ -138,10 +143,28 @@ public class UsersController(UserManager<ApplicationUser> userManager, SignInMan
         if (!string.IsNullOrWhiteSpace(request.Password))
         {
             var token = await userManager.GeneratePasswordResetTokenAsync(userToChange);
-            await userManager.ResetPasswordAsync(userToChange, token, request.Password);
+            var result = await userManager.ResetPasswordAsync(userToChange, token, request.Password);
+
+            if (!result.Succeeded)
+                throw PasswordRequirementsNotMetError.FromFailedResult(result, ApiPasswordRequirements.FromPasswordOptions(identityOptions.Value.Password));
         }
 
         return Ok();
+    }
+
+    /// <summary>
+    /// Get the password complexity requirements enforced when registering, updating a password, or
+    /// resetting a password. Backed by the same configured policy used to enforce those rules, so a
+    /// client can render a requirements checklist before submission.
+    /// </summary>
+    /// <response code="200">The configured password requirements</response>
+    [AllowAnonymous]
+    [HttpGet("users/password-requirements")]
+    public async Task<ActionResult<ApiPasswordRequirements>> GetPasswordRequirementsAsync()
+    {
+        var requirements = await mediator.Send(new GetPasswordRequirements());
+
+        return Ok(requirements);
     }
 
     /// <summary>

--- a/src/SheetMusic.Api/Users/ViewModels/ApiPasswordRequirements.cs
+++ b/src/SheetMusic.Api/Users/ViewModels/ApiPasswordRequirements.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace SheetMusic.Api.Users.ViewModels;
+
+/// <summary>
+/// The password complexity policy enforced by ASP.NET Core Identity, so API consumers can render a
+/// requirements checklist up front and interpret <see cref="Errors.PasswordRequirementsNotMetError"/>
+/// responses without hardcoding the rules. Always derived from the configured
+/// <see cref="PasswordOptions"/>, never hardcoded, so the advertised policy cannot drift from the
+/// enforced one.
+/// </summary>
+public class ApiPasswordRequirements
+{
+    public int MinimumLength { get; set; }
+    public bool RequireDigit { get; set; }
+    public bool RequireUppercase { get; set; }
+    public bool RequireLowercase { get; set; }
+    public bool RequireNonAlphanumeric { get; set; }
+    public int RequiredUniqueChars { get; set; }
+
+    public static ApiPasswordRequirements FromPasswordOptions(PasswordOptions options) => new()
+    {
+        MinimumLength = options.RequiredLength,
+        RequireDigit = options.RequireDigit,
+        RequireUppercase = options.RequireUppercase,
+        RequireLowercase = options.RequireLowercase,
+        RequireNonAlphanumeric = options.RequireNonAlphanumeric,
+        RequiredUniqueChars = options.RequiredUniqueChars
+    };
+}


### PR DESCRIPTION
Closes #253

## Problem
Password requirement failures were reported badly across all three v2 password entry points, and the requirements themselves weren't discoverable by API consumers.

## Changes
- Added GET /users/password-requirements (v2, anonymous) returning the configured Identity password policy (ApiPasswordRequirements), backed by a new GetPasswordRequirements MediatR query.
- Added PasswordRequirementsNotMetError (400), carrying ailedRequirements (stable IdentityError.Codes), messages (descriptions), and equirements as ProblemDetails extensions. Includes a shared FromFailedResult(IdentityResult, ApiPasswordRequirements) mapper used by every v2 password path.
- POST /users/register and PUT /users/{identifier} now throw on a failed IdentityResult instead of returning 201/200 with the password left unchanged or an ad-hoc { errors: [...] } shape.
- POST /users/reset-password now distinguishes a weak-password failure from an invalid/expired token. The unknown-email branch is unchanged and still returns the generic error (anti-enumeration).
- Removed the duplicated, hand-rolled complexity rules from ResetPasswordRequest.Validator (kept NotEmpty only) — Identity's PasswordValidator is now the single enforcement point, so the policy can't drift.
- ExceptionBase gained an Extensions hook and ErrorHandlerMiddleware now merges it into ProblemDetails.Extensions, serializing with camelCase to match ASP.NET Core's default response casing.

v1 (UsersV1Controller) is untouched, as scoped in the issue.

## Tests
Added/updated in SheetMusic.Api.Test/Users/UserTests.cs:
- V2_RegisterUser_ShouldReturnRequirementDetails_WhenWeakPassword
- V2_UpdateUser_ShouldReturnBadRequest_WhenWeakPassword
- V2_ResetPassword_ShouldReturnPasswordError_WhenWeakPassword
- V2_ResetPassword_ShouldReturnGenericError_WhenUnknownEmail
- V2_GetPasswordRequirements_ShouldReturnConfiguredValues

Full suite: 301/301 passing.