### PR TITLE
feat(auth): issue and rotate refresh tokens on login

### DIFF
--- a/src/SheetMusic.Api.Test/Users/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Users/UserTests.cs
@@ -1,6 +1,8 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
@@ -14,6 +16,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -929,5 +933,193 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
         var response = await client.PostAsync("token", BuildLoginForm(email, correctPassword));
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // --- Refresh tokens ---
+
+    private static FormUrlEncodedContent BuildRefreshForm(string refreshToken) => new(new List<KeyValuePair<string?, string?>>
+    {
+        new("grant_type", "refresh_token"),
+        new("refresh_token", refreshToken)
+    });
+
+    [Fact]
+    public async Task V2_GetToken_ShouldReturnRefreshToken_OnSuccessfulLogin()
+    {
+        var client = CreateV2Client();
+        const string password = "SecurePassword123!";
+        var email = await RegisterAndActivateUserAsync(client, password);
+
+        var response = await client.PostAsync("token", BuildLoginForm(email, password));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var tokens = await response.Content.ReadFromJsonAsync<ApiAccessTokens>(JsonDefaults.Options);
+        tokens.Should().NotBeNull();
+        tokens!.access_token.Should().NotBeNullOrWhiteSpace();
+        tokens.refresh_token.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task V2_RefreshToken_ShouldIssueNewTokenPair_WhenRefreshTokenIsValid()
+    {
+        var client = CreateV2Client();
+        const string password = "SecurePassword123!";
+        var email = await RegisterAndActivateUserAsync(client, password);
+
+        var loginResponse = await client.PostAsync("token", BuildLoginForm(email, password));
+        var loginTokens = await loginResponse.Content.ReadFromJsonAsync<ApiAccessTokens>(JsonDefaults.Options);
+
+        var refreshResponse = await client.PostAsync("token", BuildRefreshForm(loginTokens!.refresh_token));
+        refreshResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var refreshedTokens = await refreshResponse.Content.ReadFromJsonAsync<ApiAccessTokens>(JsonDefaults.Options);
+        refreshedTokens.Should().NotBeNull();
+        refreshedTokens!.access_token.Should().NotBeNullOrWhiteSpace();
+        refreshedTokens.refresh_token.Should().NotBeNullOrWhiteSpace();
+        refreshedTokens.refresh_token.Should().NotBe(loginTokens.refresh_token);
+    }
+
+    [Fact]
+    public async Task V2_RefreshToken_ShouldRevokeOldToken_PreventingReuse()
+    {
+        var client = CreateV2Client();
+        const string password = "SecurePassword123!";
+        var email = await RegisterAndActivateUserAsync(client, password);
+
+        var loginResponse = await client.PostAsync("token", BuildLoginForm(email, password));
+        var loginTokens = await loginResponse.Content.ReadFromJsonAsync<ApiAccessTokens>(JsonDefaults.Options);
+
+        // First use rotates the refresh token - the old one is revoked in the same operation.
+        var firstRefresh = await client.PostAsync("token", BuildRefreshForm(loginTokens!.refresh_token));
+        firstRefresh.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Reusing the original (now-revoked) refresh token must fail.
+        var secondRefresh = await client.PostAsync("token", BuildRefreshForm(loginTokens.refresh_token));
+        secondRefresh.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_RefreshToken_ShouldReturnBadRequest_WhenTokenIsUnknown()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.PostAsync("token", BuildRefreshForm("not-a-real-refresh-token"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_RefreshToken_ShouldReturnBadRequest_WhenRefreshTokenIsMissing()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.PostAsync("token", new FormUrlEncodedContent(new List<KeyValuePair<string?, string?>>
+        {
+            new("grant_type", "refresh_token")
+        }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_RefreshToken_ShouldReturnBadRequest_WhenTokenIsExpired()
+    {
+        var client = CreateV2Client();
+        const string password = "SecurePassword123!";
+        var email = await RegisterAndActivateUserAsync(client, password);
+
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var user = await userManager.FindByEmailAsync(email);
+
+        // Insert an already-expired refresh token directly, matching how AccessTokenFactory hashes
+        // the raw value before persisting it, so the endpoint can look it up by its stored digest.
+        const string rawToken = "expired-raw-refresh-token-value";
+        var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+        db.RefreshTokens.Add(new RefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = user!.Id,
+            Token = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken))),
+            CreatedAt = DateTime.UtcNow.AddDays(-8),
+            ExpiresAt = DateTime.UtcNow.AddDays(-1)
+        });
+        await db.SaveChangesAsync();
+
+        var response = await client.PostAsync("token", BuildRefreshForm(rawToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_RefreshToken_ShouldReturnBadRequest_WhenUserIsDeactivated()
+    {
+        var client = CreateV2Client();
+        const string password = "SecurePassword123!";
+        var email = await RegisterAndActivateUserAsync(client, password);
+
+        var loginResponse = await client.PostAsync("token", BuildLoginForm(email, password));
+        var loginTokens = await loginResponse.Content.ReadFromJsonAsync<ApiAccessTokens>(JsonDefaults.Options);
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+            var user = await userManager.FindByEmailAsync(email);
+            user!.Inactive = true;
+            await userManager.UpdateAsync(user);
+        }
+
+        var response = await client.PostAsync("token", BuildRefreshForm(loginTokens!.refresh_token));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_GetToken_ShouldReturnBadRequest_WhenGrantTypeIsUnsupported()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.PostAsync("token", new FormUrlEncodedContent(new List<KeyValuePair<string?, string?>>
+        {
+            new("grant_type", "client_credentials"),
+            new("username", TestUser.Testesen.Email),
+            new("password", TestUser.Testesen.Password)
+        }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_GetToken_ShouldReturnBadRequest_WhenUsernameIsMissing()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.PostAsync("token", new FormUrlEncodedContent(new List<KeyValuePair<string?, string?>>
+        {
+            new("grant_type", "basic"),
+            new("password", TestUser.Testesen.Password)
+        }));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_RefreshToken_ShouldOnlyAllowOneWinner_WhenRedeemedConcurrently()
+    {
+        var client = CreateV2Client();
+        const string password = "SecurePassword123!";
+        var email = await RegisterAndActivateUserAsync(client, password);
+
+        var loginResponse = await client.PostAsync("token", BuildLoginForm(email, password));
+        var loginTokens = await loginResponse.Content.ReadFromJsonAsync<ApiAccessTokens>(JsonDefaults.Options);
+
+        // Fire two redemptions of the same refresh token concurrently. The conditional (atomic) revoke
+        // in RefreshAccessToken.Handler must let exactly one of them succeed.
+        var responses = await Task.WhenAll(
+            client.PostAsync("token", BuildRefreshForm(loginTokens!.refresh_token)),
+            client.PostAsync("token", BuildRefreshForm(loginTokens.refresh_token)));
+
+        responses.Count(r => r.StatusCode == HttpStatusCode.OK).Should().Be(1);
+        responses.Count(r => r.StatusCode == HttpStatusCode.BadRequest).Should().Be(1);
     }
 }

--- a/src/SheetMusic.Api/Configuration/ConfigKeys.cs
+++ b/src/SheetMusic.Api/Configuration/ConfigKeys.cs
@@ -20,4 +20,16 @@ public static class ConfigKeys
     public const string RateLimitingForgotPasswordWindowSeconds = "RateLimiting:ForgotPassword:WindowSeconds";
     public const string RateLimitingTokenPermitLimit = "RateLimiting:Token:PermitLimit";
     public const string RateLimitingTokenWindowSeconds = "RateLimiting:Token:WindowSeconds";
+
+    /// <summary>
+    /// Lifetime, in minutes, of issued JWT access tokens. Defaults to 15 when unset - see
+    /// <see cref="Users.AccessTokenFactory"/>.
+    /// </summary>
+    public const string JwtAccessTokenExpiryMinutes = "Jwt:AccessTokenExpiryMinutes";
+
+    /// <summary>
+    /// Lifetime, in days, of issued refresh tokens. Defaults to 7 when unset - see
+    /// <see cref="Users.AccessTokenFactory"/>.
+    /// </summary>
+    public const string JwtRefreshTokenExpiryDays = "Jwt:RefreshTokenExpiryDays";
 }

--- a/src/SheetMusic.Api/Database/SheetMusicContext.cs
+++ b/src/SheetMusic.Api/Database/SheetMusicContext.cs
@@ -37,5 +37,13 @@ public class SheetMusicContext(DbContextOptions<SheetMusicContext> options) : Id
         modelBuilder.Entity<RefreshToken>()
             .HasIndex(rt => rt.Token)
             .IsUnique();
+
+        // Optimistic concurrency guard used by RefreshAccessToken.Handler: two concurrent requests
+        // redeeming the same refresh token both load it with RevokedAt == null, but only the first
+        // SaveChangesAsync succeeds - the second sees a stale original value and throws
+        // DbUpdateConcurrencyException, so a token can never be revoked/rotated more than once.
+        modelBuilder.Entity<RefreshToken>()
+            .Property(rt => rt.RevokedAt)
+            .IsConcurrencyToken();
     }
 }

--- a/src/SheetMusic.Api/Migrations/20260729122654_AddRefreshTokenRevokedAtConcurrencyToken.Designer.cs
+++ b/src/SheetMusic.Api/Migrations/20260729122654_AddRefreshTokenRevokedAtConcurrencyToken.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SheetMusic.Api.Database;
 
@@ -11,9 +12,11 @@ using SheetMusic.Api.Database;
 namespace SheetMusic.Api.Migrations
 {
     [DbContext(typeof(SheetMusicContext))]
-    partial class SheetMusicContextModelSnapshot : ModelSnapshot
+    [Migration("20260729122654_AddRefreshTokenRevokedAtConcurrencyToken")]
+    partial class AddRefreshTokenRevokedAtConcurrencyToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SheetMusic.Api/Migrations/20260729122654_AddRefreshTokenRevokedAtConcurrencyToken.cs
+++ b/src/SheetMusic.Api/Migrations/20260729122654_AddRefreshTokenRevokedAtConcurrencyToken.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SheetMusic.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokenRevokedAtConcurrencyToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/AccessTokenFactory.cs
+++ b/src/SheetMusic.Api/Users/AccessTokenFactory.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Configuration;
+using SheetMusic.Api.Configuration;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Errors;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SheetMusic.Api.Users;
+
+/// <summary>
+/// Creates the two pieces of an OAuth2 password/refresh_token grant response: a short-lived, signed
+/// JWT access token, and a longer-lived, opaque refresh token. Shared by <see cref="Commands.Login"/>
+/// (initial issuance) and <see cref="Commands.RefreshAccessToken"/> (rotation), so both flows apply the
+/// same expiry configuration and refresh token entropy.
+/// </summary>
+internal static class AccessTokenFactory
+{
+    /// <summary>
+    /// Creates a signed JWT identifying <paramref name="userId"/> via a <see cref="ClaimTypes.Name"/> claim.
+    /// Defaults to a 15 minute lifetime - refreshed via <see cref="Commands.RefreshAccessToken"/> using the
+    /// paired refresh token - configurable via <see cref="ConfigKeys.JwtAccessTokenExpiryMinutes"/>.
+    /// </summary>
+    public static (string AccessToken, DateTime ExpiresAt) CreateAccessToken(Guid userId, IConfiguration configuration)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.ASCII.GetBytes(configuration[ConfigKeys.Secret] ?? throw new MissingConfigurationException(ConfigKeys.Secret));
+        var expiryMinutes = GetPositiveConfiguredValue(configuration, ConfigKeys.JwtAccessTokenExpiryMinutes, 15);
+        var expiresAt = DateTime.UtcNow.AddMinutes(expiryMinutes);
+
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity([new Claim(ClaimTypes.Name, userId.ToString())]),
+            Expires = expiresAt,
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+
+        return (tokenHandler.WriteToken(token), expiresAt);
+    }
+
+    /// <summary>
+    /// Builds a new, unpersisted <see cref="RefreshToken"/> for <paramref name="userId"/>, together with
+    /// the raw (unhashed) token value to hand back to the caller. Only <see cref="HashToken"/>'s digest
+    /// of the raw value is stored on the entity - never the raw value itself - so a leaked database
+    /// (backup, log, dump) cannot be used to redeem outstanding refresh tokens. Defaults to a 7 day
+    /// lifetime, configurable via <see cref="ConfigKeys.JwtRefreshTokenExpiryDays"/>. Callers are
+    /// responsible for adding the entity to the <c>SheetMusicContext</c> and saving.
+    /// </summary>
+    public static (RefreshToken Entity, string RawToken) CreateRefreshToken(Guid userId, IConfiguration configuration)
+    {
+        var expiryDays = GetPositiveConfiguredValue(configuration, ConfigKeys.JwtRefreshTokenExpiryDays, 7);
+        var now = DateTime.UtcNow;
+        var rawToken = Convert.ToBase64String(RandomNumberGenerator.GetBytes(64));
+
+        var entity = new RefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Token = HashToken(rawToken),
+            CreatedAt = now,
+            ExpiresAt = now.AddDays(expiryDays)
+        };
+
+        return (entity, rawToken);
+    }
+
+    /// <summary>
+    /// Computes the digest of a raw refresh token value as stored in <see cref="RefreshToken.Token"/>.
+    /// Used both when persisting a newly issued token and when looking one up by its raw (presented)
+    /// value.
+    /// </summary>
+    public static string HashToken(string rawToken) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
+
+    private static int GetPositiveConfiguredValue(IConfiguration configuration, string key, int defaultValue)
+    {
+        var configured = configuration.GetValue<int?>(key);
+
+        return configured is > 0 ? configured.Value : defaultValue;
+    }
+}
+

--- a/src/SheetMusic.Api/Users/Commands/Login.cs
+++ b/src/SheetMusic.Api/Users/Commands/Login.cs
@@ -1,0 +1,57 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using SheetMusic.Api.Database;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Users.Errors;
+using SheetMusic.Api.Users.ViewModels;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Commands;
+
+/// <summary>
+/// Authenticates a user by username/password (the OAuth2 "basic" grant accepted by
+/// <c>UsersController.AuthenticateAsync</c>) and issues a fresh access token/refresh token pair.
+/// </summary>
+public class Login(string username, string password) : IRequest<ApiAccessTokens>
+{
+    public string Username { get; } = username;
+    public string Password { get; } = password;
+
+    public class Handler(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, SheetMusicContext db, IConfiguration configuration) : IRequestHandler<Login, ApiAccessTokens>
+    {
+        public async Task<ApiAccessTokens> Handle(Login request, CancellationToken cancellationToken)
+        {
+            var user = await userManager.FindByEmailAsync(request.Username);
+
+            if (user == null || user.Inactive)
+                throw new InvalidCredentialsError();
+
+            // lockoutOnFailure: true increments the failed access count and locks the account after
+            // IdentityOptions.Lockout.MaxFailedAccessAttempts is reached. The response is intentionally
+            // identical to the generic invalid-credentials case to avoid leaking account lockout state
+            // to an unauthenticated caller.
+            var result = await signInManager.CheckPasswordSignInAsync(user, request.Password, lockoutOnFailure: true);
+
+            if (!result.Succeeded)
+                throw new InvalidCredentialsError();
+
+            var (refreshToken, rawRefreshToken) = AccessTokenFactory.CreateRefreshToken(user.Id, configuration);
+            db.RefreshTokens.Add(refreshToken);
+            await db.SaveChangesAsync(cancellationToken);
+
+            var (accessToken, expiresAt) = AccessTokenFactory.CreateAccessToken(user.Id, configuration);
+
+            return new ApiAccessTokens
+            {
+                access_token = accessToken,
+                refresh_token = rawRefreshToken,
+                token_type = "bearer",
+                expires_in = (int)(expiresAt - DateTime.UtcNow).TotalSeconds,
+                scope = "sheetmusic-api"
+            };
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/Commands/RefreshAccessToken.cs
+++ b/src/SheetMusic.Api/Users/Commands/RefreshAccessToken.cs
@@ -1,0 +1,74 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using SheetMusic.Api.Database;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Users.Errors;
+using SheetMusic.Api.Users.ViewModels;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Commands;
+
+/// <summary>
+/// Exchanges a valid, active refresh token for a new access token. Rotates the refresh token in the
+/// same operation: the presented token is revoked and a brand new one is issued and returned, so a
+/// stolen-but-unused refresh token can only ever be redeemed once (see notes on issue #119 - reusing a
+/// revoked token is rejected by <see cref="Database.Entities.RefreshToken.IsActive"/>).
+/// </summary>
+public class RefreshAccessToken(string refreshToken) : IRequest<ApiAccessTokens>
+{
+    public string RefreshToken { get; } = refreshToken;
+
+    public class Handler(SheetMusicContext db, UserManager<ApplicationUser> userManager, IConfiguration configuration) : IRequestHandler<RefreshAccessToken, ApiAccessTokens>
+    {
+        public async Task<ApiAccessTokens> Handle(RefreshAccessToken request, CancellationToken cancellationToken)
+        {
+            var hashedToken = AccessTokenFactory.HashToken(request.RefreshToken);
+
+            var existingToken = await db.RefreshTokens
+                .FirstOrDefaultAsync(rt => rt.Token == hashedToken, cancellationToken);
+
+            if (existingToken == null || !existingToken.IsActive)
+                throw new InvalidRefreshTokenError();
+
+            var user = await userManager.FindByIdAsync(existingToken.UserId.ToString());
+
+            if (user == null || user.Inactive)
+                throw new InvalidRefreshTokenError();
+
+            existingToken.RevokedAt = DateTime.UtcNow;
+
+            var (newRefreshToken, rawRefreshToken) = AccessTokenFactory.CreateRefreshToken(existingToken.UserId, configuration);
+            db.RefreshTokens.Add(newRefreshToken);
+
+            try
+            {
+                // RefreshToken.RevokedAt is configured as a concurrency token (see
+                // SheetMusicContext.OnModelCreating): if another request already revoked/rotated this
+                // same token between our read and this save, the original value we loaded (null) no
+                // longer matches what's in the database and this throws instead of silently overwriting
+                // it - guaranteeing a token can never be redeemed more than once even under concurrent
+                // replay.
+                await db.SaveChangesAsync(cancellationToken);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                throw new InvalidRefreshTokenError();
+            }
+
+            var (accessToken, expiresAt) = AccessTokenFactory.CreateAccessToken(existingToken.UserId, configuration);
+
+            return new ApiAccessTokens
+            {
+                access_token = accessToken,
+                refresh_token = rawRefreshToken,
+                token_type = "bearer",
+                expires_in = (int)(expiresAt - DateTime.UtcNow).TotalSeconds,
+                scope = "sheetmusic-api"
+            };
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/Errors/InvalidCredentialsError.cs
+++ b/src/SheetMusic.Api/Users/Errors/InvalidCredentialsError.cs
@@ -1,0 +1,14 @@
+using SheetMusic.Api.Errors;
+using System.Net;
+
+namespace SheetMusic.Api.Users.Errors;
+
+/// <summary>
+/// The provided username/password combination did not authenticate, the user does not exist, or the
+/// user is inactive. Deliberately a single generic error for all three cases - distinguishing them in
+/// the response would let a caller enumerate registered accounts or account state.
+/// </summary>
+public class InvalidCredentialsError() : ExceptionBase("Username or password is incorrect")
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+}

--- a/src/SheetMusic.Api/Users/Errors/InvalidRefreshTokenError.cs
+++ b/src/SheetMusic.Api/Users/Errors/InvalidRefreshTokenError.cs
@@ -1,0 +1,12 @@
+using SheetMusic.Api.Errors;
+using System.Net;
+
+namespace SheetMusic.Api.Users.Errors;
+
+/// <summary>
+/// The supplied refresh token does not exist, has already been used/revoked, or has expired.
+/// </summary>
+public class InvalidRefreshTokenError() : ExceptionBase("Refresh token is invalid, expired, or has already been used")
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+}

--- a/src/SheetMusic.Api/Users/RequestModels/LoginRequest.cs
+++ b/src/SheetMusic.Api/Users/RequestModels/LoginRequest.cs
@@ -1,14 +1,45 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using FluentValidation;
+using System.Linq;
 
 namespace SheetMusic.Api.Users.RequestModels;
 
 public class LoginRequest
 {
+    /// <summary>
+    /// The OAuth2 grant type. Either <c>"basic"</c> (username/password) or <c>"refresh_token"</c>.
+    /// </summary>
     public string grant_type { get; set; } = null!;
+
+    /// <summary>The account email address. Required when <see cref="grant_type"/> is <c>"basic"</c>.</summary>
     public string username { get; set; } = null!;
+
+    /// <summary>The account password. Required when <see cref="grant_type"/> is <c>"basic"</c>.</summary>
     public string password { get; set; } = null!;
+
+    /// <summary>A previously issued refresh token. Required when <see cref="grant_type"/> is <c>"refresh_token"</c>.</summary>
     public string? refresh_token { get; set; }
 
     // Optional
     //public string scope { get; set; }
+
+    public class Validator : AbstractValidator<LoginRequest>
+    {
+        private static readonly string[] SupportedGrantTypes = ["basic", "refresh_token"];
+
+        public Validator()
+        {
+            RuleFor(r => r.grant_type)
+                .NotEmpty().WithMessage("grant_type is required.")
+                .Must(g => SupportedGrantTypes.Contains(g)).WithMessage($"grant_type must be one of: {string.Join(", ", SupportedGrantTypes)}.")
+                .When(r => !string.IsNullOrEmpty(r.grant_type));
+
+            // The "refresh_token" grant exchanges a refresh token for a new token pair and needs no
+            // credentials. The "basic" grant (the legacy/password grant this API accepts) requires
+            // username/password.
+            RuleFor(r => r.username).NotEmpty().WithMessage("username is required.").When(r => r.grant_type != "refresh_token");
+            RuleFor(r => r.password).NotEmpty().WithMessage("password is required.").When(r => r.grant_type != "refresh_token");
+            RuleFor(r => r.refresh_token).NotEmpty().WithMessage("refresh_token is required.").When(r => r.grant_type == "refresh_token");
+        }
+    }
 }
+

--- a/src/SheetMusic.Api/Users/UsersController.cs
+++ b/src/SheetMusic.Api/Users/UsersController.cs
@@ -4,9 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using SheetMusic.Api.Configuration;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Errors;
@@ -17,11 +15,9 @@ using SheetMusic.Api.Users.Queries;
 using SheetMusic.Api.Users.RequestModels;
 using SheetMusic.Api.Users.ViewModels;
 using System;
-using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net;
 using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace SheetMusic.Api.Users;
@@ -32,54 +28,30 @@ namespace SheetMusic.Api.Users;
 [ApiVersion("2.0")]
 [Authorize]
 [ApiController]
-public class UsersController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, IConfiguration configuration, IMediator mediator, IOptions<IdentityOptions> identityOptions) : ControllerBase
+public class UsersController(UserManager<ApplicationUser> userManager, IMediator mediator, IOptions<IdentityOptions> identityOptions) : ControllerBase
 {
     /// <summary>
-    /// Authenticate using Identity and receive a JWT token.
+    /// Authenticate using Identity and receive a JWT access token and refresh token. Supports two
+    /// grant types via <paramref name="request"/>.grant_type: "basic" (username/password) issues a new
+    /// token pair; "refresh_token" exchanges a still-active refresh token for a new, rotated pair.
     /// </summary>
-    /// <param name="request">The username and password to authenticate with</param>
-    /// <response code="200">The access token</response>
-    /// <response code="400">Username or password is incorrect</response>
+    /// <param name="request">The grant type, plus either username/password or a refresh_token</param>
+    /// <response code="200">The access token and refresh token</response>
+    /// <response code="400">Username or password is incorrect, or the refresh token is invalid/expired</response>
     [AllowAnonymous]
     [EnableRateLimiting(RateLimitPolicies.Token)]
     [ProducesResponseType(typeof(ApiAccessTokens), (int)HttpStatusCode.OK)]
     [HttpPost("token")]
     public async Task<IActionResult> AuthenticateAsync([FromForm] LoginRequest request)
     {
-        var user = await userManager.FindByEmailAsync(request.username);
-
-        if (user == null || user.Inactive)
-            return BadRequest(new { message = "Username or password is incorrect" });
-
-        // lockoutOnFailure: true increments the failed access count and locks the account after
-        // IdentityOptions.Lockout.MaxFailedAccessAttempts is reached. The response is intentionally
-        // identical to the generic invalid-credentials case to avoid leaking account lockout state
-        // to an unauthenticated caller.
-        var result = await signInManager.CheckPasswordSignInAsync(user, request.password, lockoutOnFailure: true);
-
-        if (!result.Succeeded)
-            return BadRequest(new { message = "Username or password is incorrect" });
-
-        var tokenHandler = new JwtSecurityTokenHandler();
-        var key = Encoding.ASCII.GetBytes(configuration[ConfigKeys.Secret] ?? throw new MissingConfigurationException(ConfigKeys.Secret));
-        var expires = DateTime.UtcNow.AddDays(7);
-
-        var tokenDescriptor = new SecurityTokenDescriptor
+        if (request.grant_type == "refresh_token")
         {
-            Subject = new ClaimsIdentity([new Claim(ClaimTypes.Name, user.Id.ToString())]),
-            Expires = expires,
-            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
-        };
-        var token = tokenHandler.CreateToken(tokenDescriptor);
-        var tokenString = tokenHandler.WriteToken(token);
+            var refreshed = await mediator.Send(new RefreshAccessToken(request.refresh_token!));
+            return Ok(refreshed);
+        }
 
-        return Ok(new ApiAccessTokens
-        {
-            expires_in = (expires - DateTime.UtcNow).Seconds,
-            access_token = tokenString,
-            token_type = "bearer",
-            scope = "sheetmusic-api"
-        });
+        var tokens = await mediator.Send(new Login(request.username, request.password));
+        return Ok(tokens);
     }
 
     /// <summary>


### PR DESCRIPTION
Implements the login + refresh-token portion of #119 (Phase 2: Authentication endpoints CQRS).

## What changed
- New CQRS commands: Login (validates credentials, issues access + refresh token) and RefreshAccessToken (validates and rotates a refresh token)
- POST /token (api-version 2.0) now supports grant_type=basic (existing password login) and grant_type=refresh_token, both delegated entirely to MediatR - no more inline JWT-building logic in UsersController
- Refresh tokens are stored as a SHA-256 hash, never in plaintext
- Refresh token rotation is race-safe: RefreshToken.RevokedAt is an EF Core optimistic concurrency token, so concurrent redemption of the same token can only succeed once
- Deactivated users and unsupported grant_type values are rejected
- Access token expiry now defaults to 15 minutes (was 7 days); refresh token expiry defaults to 7 days - both configurable via new Jwt:AccessTokenExpiryMinutes / Jwt:RefreshTokenExpiryDays config keys
- Added a metadata-only EF Core migration for the new concurrency token

## Out of scope (left for follow-up work on #119)
- Register/ChangePassword/Logout as CQRS commands
- Renaming to a dedicated AuthController with /auth/* routes
- Revoking outstanding refresh tokens on password change/reset/logout
- Legacy UsersV1Controller untouched

## Testing
Added integration tests covering: refresh token issuance on login, successful rotation, reuse-after-rotation rejection, unknown/expired tokens, deactivated-user rejection, unsupported grant type, missing credentials, and concurrent redemption (only one of two simultaneous requests wins). Full suite: 312/312 passing.

Refs #119