### PR TITLE
fix(deploy): use vars instead of secrets for Azure identity in login step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,16 +91,16 @@ jobs:
       - name: Azure login
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       # Deploy sequence, part 1 of 4 (issue #246, #234 decision 11): deploys the new image and creates
       # the new revision with test's real replica counts (see AppHost.cs) - no scale trickery needed.
       - name: Deploy test infrastructure and new image
         run: aspire do provision-sheetmusic-api-test-containerapp --non-interactive
         env:
-          Azure__SubscriptionId: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          Azure__SubscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
           Azure__Location: ${{ vars.AZURE_LOCATION }}
           Azure__ResourceGroup: ${{ vars.AZURE_RESOURCE_GROUP }}
           Parameters__resend_api_key: ${{ secrets.RESEND_API_KEY }}
@@ -199,14 +199,14 @@ jobs:
       - name: Azure login
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy production infrastructure and new image
         run: aspire do provision-sheetmusic-api-containerapp --non-interactive
         env:
-          Azure__SubscriptionId: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          Azure__SubscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
           Azure__Location: ${{ vars.AZURE_LOCATION }}
           Azure__ResourceGroup: ${{ vars.AZURE_RESOURCE_GROUP }}
           Parameters__resend_api_key: ${{ secrets.RESEND_API_KEY }}


### PR DESCRIPTION
## Problem
The Deploy to test job in Build and Deploy failed at the zure/login step:

```n Login failed with Error: Using auth-type: SERVICE_PRINCIPAL. Not all values are present. Ensure 'client-id' and 'tenant-id' are supplied.
```n
Run: https://github.com/Stavanger-Brass-Band/sheetmusic-api/actions/runs/30461898912/job/90610095327

## Root cause
AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_SUBSCRIPTION_ID are configured as repository **variables**, not secrets, but deploy.yml read them via secrets.*, which resolved to empty.

## Fix
Read these three values via ars.* in both the deploy-test and deploy-prod jobs (azure/login step and the Azure__SubscriptionId env var). These identifiers aren't sensitive - it's the standard non-secret OIDC federated login pattern - so no new secrets are needed.