### PR TITLE
fix(deploy): pin Azure.Identity to a version supporting AZURE_TOKEN_CREDENTIALS=ManagedIdentityCredential

### DIFF
--- a/src/SheetMusic.Api/SheetMusic.Api.csproj
+++ b/src/SheetMusic.Api/SheetMusic.Api.csproj
@@ -18,6 +18,11 @@
 		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
 		<PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.4.6" />
 		<PackageReference Include="Aspire.Azure.Search.Documents" Version="13.4.6" />
+		<!-- Microsoft.Data.SqlClient's transitive Azure.Identity is too old to understand Aspire's
+		     AZURE_TOKEN_CREDENTIALS=ManagedIdentityCredential (only 1.15.0+ accepts named credential
+		     types; earlier versions only accept 'dev'/'prod'), breaking "Active Directory Default" SQL
+		     auth in Azure Container Apps. Force a compatible version for the whole app. -->
+		<PackageReference Include="Azure.Identity" Version="1.21.0" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
 		<PackageReference Include="MediatR" Version="14.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />


### PR DESCRIPTION
## Problem

After #262 and #263 landed (correct connection string env var + re-provisioning the migration job), the migration job now reaches the SQL connection but fails differently:

```
Migration failed: Microsoft.Data.SqlClient.SqlException (0x80131904): Invalid value for environment variable AZURE_TOKEN_CREDENTIALS: ManagedIdentityCredential. Valid values are 'dev' or 'prod'.
 ---> System.InvalidOperationException: Invalid value for environment variable AZURE_TOKEN_CREDENTIALS: ManagedIdentityCredential. Valid values are 'dev' or 'prod'.
   at Azure.Identity.DefaultAzureCredentialFactory.CreateCredentialChain()
   ...
   at Microsoft.Data.SqlClient.ActiveDirectoryAuthenticationProvider.CreateTokenCredentialInstance(...)
```

## Root cause

Aspire's Azure Container Apps/App Service hosting sets `AZURE_TOKEN_CREDENTIALS=ManagedIdentityCredential` on every deployed compute resource so `DefaultAzureCredential` skips straight to managed identity in production (see [Default Azure credential](https://aspire.dev) docs).

That env var name is only understood by `Azure.Identity` 1.15.0+, which expanded valid values to named credential types (`ManagedIdentityCredential`, `EnvironmentCredential`, etc). Earlier versions (including 1.14.0-1.14.2) only support the narrower `'dev'`/`'prod'` values introduced in 1.14.0.

`Microsoft.Data.SqlClient`'s `Authentication=Active Directory Default` SQL auth builds its own `DefaultAzureCredential`, and its `Azure.Identity` transitive dependency resolved to **1.14.2** - too old to understand `ManagedIdentityCredential`, so it throws instead of authenticating.

## Fix

Add an explicit `Azure.Identity` package reference pinned to `1.21.0` in `SheetMusic.Api.csproj`, so NuGet resolves the whole app (including `Microsoft.Data.SqlClient`'s internal use) to a version that understands the value Aspire sets.

## Verification

- `dotnet restore` confirms the resolved `Azure.Identity` version is now `1.21.0` (previously `1.14.2`), verified via `project.assets.json`.
- `dotnet build src/SheetMusic.sln` succeeds with no new warnings/errors.
