### PR TITLE
fix(deploy): use prod environment name to match federated identity credential

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,9 @@ jobs:
     # scoping - production deploys the same Azure resource group/Azure identity as test (kept as
     # repo-level vars/secrets, not duplicated per environment), just its own frontend URL via this
     # environment's own `vars.EMAIL_FRONTEND_BASE_URL` and a different container app/job.
-    environment: production
+    # Name must be "prod", not "production" - it must match the Subject configured on the Azure AD
+    # app registration's federated identity credential exactly (repo:<owner>/<repo>:environment:prod).
+    environment: prod
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Production deploy failed with AADSTS700213 because the workflow's deploy-prod job used the GitHub Environment name production, but the Azure AD app registration's federated identity credential subject expects nvironment:prod.

Renamed the environment to prod in .github/workflows/deploy.yml so the presented OIDC token subject matches the federated credential.

**Follow-up required**: if the GitHub Environment is currently named production in repo settings, it must be renamed to prod (or a new prod environment created with the same variables/secrets and protection rules) for this to take effect.