### PR TITLE
fix(parts): return 409 conflict instead of 500 when deleting a part in use

### DIFF
--- a/src/SheetMusic.Api.Test/Parts/PartTests.cs
+++ b/src/SheetMusic.Api.Test/Parts/PartTests.cs
@@ -1,4 +1,8 @@
 ﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SheetMusic.Api.Database;
+using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Parts.ViewModels;
 using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
@@ -6,6 +10,8 @@ using SheetMusic.Api.Test.Infrastructure.TestCollections;
 using SheetMusic.Api.Test.Utility;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
@@ -216,6 +222,41 @@ public class PartTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
         var client = factory.CreateClient();
         var response = await client.DeleteAsync($"parts/{part.Name}");
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task DeletePart_ShouldReturnConflict_WhenPartIsUsedInSet()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var part = await new PartDataBuilder(adminClient).ProvisionSinglePartAsync();
+        var set = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+
+        var path = $"{Path.GetTempPath()}{part.Name}.pdf";
+        await File.WriteAllTextAsync(path, "content");
+        await FileUploader.UploadOneFile(path, adminClient, $"sheetmusic/sets/{set.Id}/parts/{part.Name}/content?api-version=2.0");
+
+        var response = await adminClient.DeleteAsync($"parts/{part.Name}");
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task DeletePart_ShouldReturnConflict_WhenPartIsAssignedToMusician()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var part = await new PartDataBuilder(adminClient).ProvisionSinglePartAsync();
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            var userGroupId = await db.UserGroups.Select(g => g.Id).FirstAsync();
+            var musician = new Musician { Id = Guid.NewGuid(), Name = $"Musician-{Guid.NewGuid()}", UserGroupId = userGroupId };
+            db.Musicians.Add(musician);
+            db.Set<MusicianMusicPart>().Add(new MusicianMusicPart { Id = Guid.NewGuid(), MusicianId = musician.Id, MusicPartId = part.Id });
+            await db.SaveChangesAsync();
+        }
+
+        var response = await adminClient.DeleteAsync($"parts/{part.Name}");
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
     [Fact]

--- a/src/SheetMusic.Api/Parts/Commands/DeletePart.cs
+++ b/src/SheetMusic.Api/Parts/Commands/DeletePart.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Errors;
+using SheetMusic.Api.Parts.Errors;
 using System;
 using System.Linq;
 using System.Threading;
@@ -25,7 +26,7 @@ public class DeletePart(Guid partId) : IRequest
             if (part == null) throw new NotFoundError(request.PartId.ToString(), "Part not found");
 
             if (part.MusicianMusicParts.Any() || part.Parts.Any())
-                throw new InvalidOperationException("Part is linked to musicians or sets and cannot be deleted");
+                throw new PartInUseError(part.Name);
 
             db.MusicParts.Remove(part);
             await db.SaveChangesAsync(cancellationToken);

--- a/src/SheetMusic.Api/Parts/Errors/PartInUseError.cs
+++ b/src/SheetMusic.Api/Parts/Errors/PartInUseError.cs
@@ -1,0 +1,9 @@
+using SheetMusic.Api.Errors;
+using System.Net;
+
+namespace SheetMusic.Api.Parts.Errors;
+
+public class PartInUseError(string partName) : ExceptionBase($"Part '{partName}' is linked to musicians or sets and cannot be deleted")
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.Conflict;
+}


### PR DESCRIPTION
Fixes a 500 Internal Server Error reported by a user when deleting a part (stemme) that is still linked to a set or musician.

DeletePart threw a generic InvalidOperationException in that case, which isn't caught by ErrorHandlerMiddleware's ExceptionBase handler, so it fell through to the generic handler and returned a bare 500 instead of a meaningful error.

Added PartInUseError (ExceptionBase, 409 Conflict) following the existing PartAlreadyExistsError pattern, and added tests covering deletion of a part still assigned to a set and one still assigned to a musician.