### PR TITLE
fix(odata): apply $orderby, $skip and $top on GET /projects and /parts

### DIFF
--- a/src/SheetMusic.Api.Test/Parts/PartTests.cs
+++ b/src/SheetMusic.Api.Test/Parts/PartTests.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Xunit;
@@ -530,4 +531,70 @@ public class PartTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
         var response = await client.DeleteAsync($"parts/{part.Name}");
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
+
+    #region OData $orderby, $skip and $top
+
+    private static async Task SeedPartsAsync(HttpClient client, params string[] names)
+    {
+        foreach (var name in names)
+            await client.PostAsJsonAsync("parts", new { Name = name, SortOrder = 1, Indexable = false });
+    }
+
+    [Fact]
+    public async Task GetPartList_ShouldRespectOrderBy_WhenOrderByAscendingProvided()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedPartsAsync(client, "Zulu part", "Alfa part", "Mike part");
+
+        var response = await client.GetAsync("parts?$orderby=name asc");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var parts = await response.Content.ReadFromJsonAsync<List<ApiPart>>(JsonDefaults.Options);
+        parts!.Select(p => p.Name).Should().Equal("Alfa part", "Mike part", "Zulu part");
+    }
+
+    [Fact]
+    public async Task GetPartList_ShouldRespectOrderBy_WhenOrderByDescendingProvided()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedPartsAsync(client, "Zulu part", "Alfa part", "Mike part");
+
+        var response = await client.GetAsync("parts?$orderby=name desc");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var parts = await response.Content.ReadFromJsonAsync<List<ApiPart>>(JsonDefaults.Options);
+        parts!.Select(p => p.Name).Should().Equal("Zulu part", "Mike part", "Alfa part");
+    }
+
+    [Fact]
+    public async Task GetPartList_ShouldRespectTop_WhenTopProvided()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedPartsAsync(client, "Alfa part", "Bravo part", "Charlie part");
+
+        var response = await client.GetAsync("parts?$orderby=name asc&$top=2");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var parts = await response.Content.ReadFromJsonAsync<List<ApiPart>>(JsonDefaults.Options);
+        parts!.Select(p => p.Name).Should().Equal("Alfa part", "Bravo part");
+    }
+
+    [Fact]
+    public async Task GetPartList_ShouldRespectSkipAndTop_WhenBothProvided()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedPartsAsync(client, "Alfa part", "Bravo part", "Charlie part", "Delta part");
+
+        var response = await client.GetAsync("parts?$orderby=name asc&$skip=1&$top=2");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var parts = await response.Content.ReadFromJsonAsync<List<ApiPart>>(JsonDefaults.Options);
+        parts!.Select(p => p.Name).Should().Equal("Bravo part", "Charlie part");
+    }
+
+    #endregion
 }

--- a/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Xunit;
@@ -519,4 +520,77 @@ public class ProjectTests(SheetMusicWebAppFactory factory) : IClassFixture<Sheet
         });
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    #region OData $orderby, $skip and $top
+
+    private static async Task SeedProjectsAsync(HttpClient client, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            await client.PostAsJsonAsync("projects", new
+            {
+                Name = name,
+                StartDate = DateTimeOffset.UtcNow.AddMonths(-1),
+                EndDate = DateTimeOffset.UtcNow.AddMonths(1)
+            });
+        }
+    }
+
+    [Fact]
+    public async Task GetProjects_ShouldRespectOrderBy_WhenOrderByAscendingProvided()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedProjectsAsync(client, "Zulu project", "Alfa project", "Mike project");
+
+        var response = await client.GetAsync("projects?$orderby=name asc");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var projects = await response.Content.ReadFromJsonAsync<List<ApiProject>>(JsonDefaults.Options);
+        projects!.Select(p => p.Name).Should().Equal("Alfa project", "Mike project", "Zulu project");
+    }
+
+    [Fact]
+    public async Task GetProjects_ShouldRespectOrderBy_WhenOrderByDescendingProvided()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedProjectsAsync(client, "Zulu project", "Alfa project", "Mike project");
+
+        var response = await client.GetAsync("projects?$orderby=name desc");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var projects = await response.Content.ReadFromJsonAsync<List<ApiProject>>(JsonDefaults.Options);
+        projects!.Select(p => p.Name).Should().Equal("Zulu project", "Mike project", "Alfa project");
+    }
+
+    [Fact]
+    public async Task GetProjects_ShouldRespectTop_WhenTopProvided()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedProjectsAsync(client, "Alfa project", "Bravo project", "Charlie project");
+
+        var response = await client.GetAsync("projects?$orderby=name asc&$top=2");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var projects = await response.Content.ReadFromJsonAsync<List<ApiProject>>(JsonDefaults.Options);
+        projects!.Select(p => p.Name).Should().Equal("Alfa project", "Bravo project");
+    }
+
+    [Fact]
+    public async Task GetProjects_ShouldRespectSkipAndTop_WhenBothProvided()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedProjectsAsync(client, "Alfa project", "Bravo project", "Charlie project", "Delta project");
+
+        var response = await client.GetAsync("projects?$orderby=name asc&$skip=1&$top=2");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var projects = await response.Content.ReadFromJsonAsync<List<ApiProject>>(JsonDefaults.Options);
+        projects!.Select(p => p.Name).Should().Equal("Bravo project", "Charlie project");
+    }
+
+    #endregion
 }

--- a/src/SheetMusic.Api/Parts/Queries/GetPartCollection.cs
+++ b/src/SheetMusic.Api/Parts/Queries/GetPartCollection.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.OData;
+using SheetMusic.Api.OData.Expression;
 using SheetMusic.Api.OData.Extensions;
 using SheetMusic.Api.OData.MVC;
 using SheetMusic.Api.Database.Entities;
@@ -19,6 +20,13 @@ public class GetPartCollection(ODataQueryParams queryParams) : IRequest<List<Mus
 
     public class Handler(SheetMusicContext db) : IRequestHandler<GetPartCollection, List<MusicPart>>
     {
+        private static readonly Action<ODataFieldMapping<MusicPart>> FieldMapping = m =>
+        {
+            m.MapField("name", p => p.Name);
+            m.MapField("indexable", p => p.Indexable);
+            m.MapField("sortOrder", p => p.SortOrder);
+        };
+
         public async Task<List<MusicPart>> Handle(GetPartCollection request, CancellationToken cancellationToken)
         {
             var query = db.MusicParts.AsQueryable();
@@ -30,16 +38,18 @@ public class GetPartCollection(ODataQueryParams queryParams) : IRequest<List<Mus
             }
 
             if (request.QueryParams != null && request.QueryParams.HasFilter)
-            {
-                query = query.ApplyODataFilters(request.QueryParams, m =>
-                {
-                    m.MapField("name", p => p.Name);
-                    m.MapField("indexable", p => p.Indexable);
-                    m.MapField("sortOrder", p => p.SortOrder);
-                });
-            }
+                query = query.ApplyODataFilters(request.QueryParams, FieldMapping);
 
-            var results = await query.ToListAsync();
+            if (request.QueryParams != null && request.QueryParams.OrderBy.Any())
+                query = query.ApplyODataOrderBy(request.QueryParams, FieldMapping);
+
+            if (request.QueryParams?.Skip is not null)
+                query = query.Skip(request.QueryParams.Skip.Value);
+
+            if (request.QueryParams?.Top is not null)
+                query = query.Take(request.QueryParams.Top.Value);
+
+            var results = await query.ToListAsync(cancellationToken);
 
             return results;
         }

--- a/src/SheetMusic.Api/Projects/Queries/GetProjectCollection.cs
+++ b/src/SheetMusic.Api/Projects/Queries/GetProjectCollection.cs
@@ -3,9 +3,12 @@ using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.OData;
+using SheetMusic.Api.OData.Expression;
 using SheetMusic.Api.OData.Extensions;
 using SheetMusic.Api.OData.MVC;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,19 +20,28 @@ public class GetProjectCollection(ODataQueryParams? queryParams) : IRequest<List
 
     public class Handler(SheetMusicContext db) : IRequestHandler<GetProjectCollection, List<Project>>
     {
+        private static readonly Action<ODataFieldMapping<Project>> FieldMapping = m =>
+        {
+            m.MapField("startDate", p => p.StartDate);
+            m.MapField("endDate", p => p.EndDate);
+            m.MapField("name", p => p.Name);
+        };
+
         public async Task<List<Project>> Handle(GetProjectCollection request, CancellationToken cancellationToken)
         {
             var query = db.Projects.AsQueryable();
 
             if (request.QueryParams != null && request.QueryParams.HasFilter)
-            {
-                query = query.ApplyODataFilters(request.QueryParams, m =>
-                {
-                    m.MapField("startDate", p => p.StartDate);
-                    m.MapField("endDate", p => p.EndDate);
-                    m.MapField("name", p => p.Name);
-                });
-            }
+                query = query.ApplyODataFilters(request.QueryParams, FieldMapping);
+
+            if (request.QueryParams != null && request.QueryParams.OrderBy.Any())
+                query = query.ApplyODataOrderBy(request.QueryParams, FieldMapping);
+
+            if (request.QueryParams?.Skip is not null)
+                query = query.Skip(request.QueryParams.Skip.Value);
+
+            if (request.QueryParams?.Top is not null)
+                query = query.Take(request.QueryParams.Top.Value);
 
             return await query.ToListAsync(cancellationToken);
         }


### PR DESCRIPTION
## Summary
Manual testing of the documented OData support on GET /projects showed that $filter works correctly, but $orderby, $skip and $top had no effect on the returned results, even though the endpoint's XML doc / Swagger description implies full OData support. GetPartCollection.Handler had the same gap.

## Root cause
GetProjectCollection.Handler and GetPartCollection.Handler only called ApplyODataFilters on the query - they never applied ApplyODataOrderBy, .Skip(), or .Take() from the incoming ODataQueryParams, unlike GetSets.Handler.

## Fix
- Apply ApplyODataOrderBy, .Skip() and .Take() in both GetProjectCollection.Handler and GetPartCollection.Handler, following the pattern used in GetSets.Handler.
- Pass the cancellation token through in GetPartCollection's ToListAsync call.
- Add integration tests asserting $orderby, $skip and $top work on GET /projects and GET /parts.

Fixes #268