### PR TITLE
fix(cors): declare a single CORS policy and enforce it correctly

### DIFF
--- a/.github/agents/sheetmusic-dev.agent.md
+++ b/.github/agents/sheetmusic-dev.agent.md
@@ -87,6 +87,11 @@ When adding a new entity:
 
 When changing existing behavior (bug fix, field addition, small tweak) outside the full endpoint/entity flow above, still add or update a test covering the change before considering the task complete.
 
+### AppHost / Aspire Changes
+
+- When investigating Aspire hosting APIs or Azure provisioning types (e.g. `Azure.Provisioning.*`, `PublishAsAzureContainerApp` customization), use `aspire docs search` / `aspire docs api search` (or the aspire-deployment skill) to find the exact API shape - never reflect over installed NuGet DLLs to guess member names
+- Do not invent builder methods, overloads, or provisioning properties; verify them against Aspire docs first
+
 ## Code Style Enforcement
 
 - Always use primary constructors for DI

--- a/src/SheetMusic.Api.Test/Tests/Shared/CorsTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/Shared/CorsTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using SheetMusic.Api.Test.Infrastructure;
+using SheetMusic.Api.Test.Infrastructure.TestCollections;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SheetMusic.Api.Test.Tests.Shared;
+
+/// <summary>
+/// UseCors must run before UseAuthentication/UseAuthorization (see Program.cs) so that CORS headers are
+/// present even on 401/403 responses - otherwise the browser reports a CORS error instead of surfacing
+/// the real auth failure to the frontend.
+/// </summary>
+[Collection(Collections.Set)]
+public class CorsTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusicWebAppFactory>
+{
+    [Fact]
+    public async Task GetCategoryList_ShouldIncludeCorsHeader_WhenUnauthenticatedFromAllowedOrigin()
+    {
+        var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "categories");
+        request.Headers.Add("Origin", "https://medlem.stavanger-brassband.no");
+
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainSingle(h => h.Key == "Access-Control-Allow-Origin")
+            .Which.Value.Should().ContainSingle("https://medlem.stavanger-brassband.no");
+    }
+
+    [Fact]
+    public async Task GetCategoryList_ShouldNotIncludeCorsHeader_WhenOriginNotAllowed()
+    {
+        var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "categories");
+        request.Headers.Add("Origin", "https://not-allowed.example.com");
+
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().NotContain(h => h.Key == "Access-Control-Allow-Origin");
+    }
+}

--- a/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
+++ b/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
@@ -100,8 +100,7 @@ public static class IServiceCollectionExtensions
         services.AddCors(options =>
         {
             // Same binary serves both test and prod (see AppHost.cs), so this list is the union of both
-            // environments' real frontend origins - keep it in sync with the per-app ACA ingress CORS
-            // policies declared there.
+            // environments' real frontend origins.
             options.AddPolicy("AllowMember", builder =>
                 builder.WithOrigins("https://medlem.stavanger-brassband.no",
                                     "https://orange-mud-00eed1803.1.azurestaticapps.net",

--- a/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
+++ b/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
@@ -99,9 +99,12 @@ public static class IServiceCollectionExtensions
     {
         services.AddCors(options =>
         {
+            // Same binary serves both test and prod (see AppHost.cs), so this list is the union of both
+            // environments' real frontend origins - keep it in sync with the per-app ACA ingress CORS
+            // policies declared there.
             options.AddPolicy("AllowMember", builder =>
-                builder.WithOrigins("https://sheetmusic-member.azurewebsites.net",
-                                    "https://medlem.stavanger-brassband.no",
+                builder.WithOrigins("https://medlem.stavanger-brassband.no",
+                                    "https://orange-mud-00eed1803.1.azurestaticapps.net",
                                     "http://localhost:5000",
                                     "http://localhost:5100",
                                     "https://localhost:5001")

--- a/src/SheetMusic.Api/Program.cs
+++ b/src/SheetMusic.Api/Program.cs
@@ -104,10 +104,13 @@ app.UseMiddleware<ErrorHandlerMiddleware>();
 
 app.UseForwardedHeaders();
 app.UseRouting();
+// Before auth (documented ASP.NET Core ordering): otherwise a 401/403 short-circuits before reaching
+// UseCors, so the response has no CORS headers and the browser reports a CORS error instead of the
+// real auth failure.
+app.UseCors("AllowMember");
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseHttpsRedirection();
-app.UseCors("AllowMember");
 app.UseRateLimiter();
 
 var provider = app.Services.GetRequiredService<IApiVersionDescriptionProvider>();

--- a/src/SheetMusic.AppHost/AppHost.cs
+++ b/src/SheetMusic.AppHost/AppHost.cs
@@ -100,9 +100,7 @@ builder.AddAzureContainerAppEnvironment("sheetmusic-aca-env")
 // from clobbering each other (issue #236) on the one shared Search service above. `minReplicas`/
 // `maxReplicas` are this app's real steady-state scale (see "Scale rules" above). `frontendBaseUrl` is
 // this app's own frontend deployment (test and prod are different URLs - see the parameters above).
-// `corsAllowedOrigins` is this app's own set of browser origins - test and prod are served from
-// different frontend hosts, so each app declares only the origin(s) it actually needs.
-IResourceBuilder<ProjectResource> AddApi(string name, IResourceBuilder<IResourceWithConnectionString> database, string searchIndexPrefix, int minReplicas, int maxReplicas, IResourceBuilder<ParameterResource> frontendBaseUrl, string[] corsAllowedOrigins)
+IResourceBuilder<ProjectResource> AddApi(string name, IResourceBuilder<IResourceWithConnectionString> database, string searchIndexPrefix, int minReplicas, int maxReplicas, IResourceBuilder<ParameterResource> frontendBaseUrl)
 {
     var minReplicasParameter = builder.AddParameter($"{name}-min-replicas", minReplicas.ToString());
     var maxReplicasParameter = builder.AddParameter($"{name}-max-replicas", maxReplicas.ToString());
@@ -137,25 +135,6 @@ IResourceBuilder<ProjectResource> AddApi(string name, IResourceBuilder<IResource
             // ACA does not infer probes from `WithHttpHealthCheck` the way local `aspire run`
             // health-checking does - both must be set explicitly here.
             app.Configuration.Ingress.TargetPort = 8080;
-
-            // ACA ingress-level CORS policy, declared here so it's part of the AppHost model and gets
-            // reapplied on every deploy - previously this had to be set by hand against the Container
-            // App resource (e.g. via the portal or `az containerapp ingress cors enable`), and Aspire's
-            // full-resource redeploy silently wiped it back to "no CORS policy" every time, since nothing
-            // in the deployment model declared it. Keep this in sync with AddSheetMusicSecurity's
-            // "AllowMember" policy (see Configuration/IServiceCollectionExtensions.cs). `corsAllowedOrigins`
-            // is this app's own real frontend origin(s) - test and prod intentionally do not share a list.
-            var corsPolicy = new ContainerAppCorsPolicy
-            {
-                AllowedMethods = { "*" },
-                AllowedHeaders = { "*" },
-                AllowCredentials = true,
-            };
-            foreach (var origin in corsAllowedOrigins)
-            {
-                corsPolicy.AllowedOrigins.Add(origin);
-            }
-            app.Configuration.Ingress.CorsPolicy = corsPolicy;
 
             var container = app.Template.Containers[0].Value!;
             container.Probes.Add(new ContainerAppProbe
@@ -225,10 +204,10 @@ void AddMigrationJob(string name, IResourceBuilder<IResourceWithConnectionString
         .PublishAsAzureContainerAppJob();
 }
 
-var api = AddApi("sheetmusic-api", db, searchIndexPrefix: "", minReplicas: 1, maxReplicas: 3, frontendBaseUrl: emailFrontendBaseUrl, corsAllowedOrigins: ["https://medlem.stavanger-brassband.no"]);
+var api = AddApi("sheetmusic-api", db, searchIndexPrefix: "", minReplicas: 1, maxReplicas: 3, frontendBaseUrl: emailFrontendBaseUrl);
 AddMigrationJob("sheetmusic-api-migrate", db);
 
-var apiTest = AddApi("sheetmusic-api-test", testDb, searchIndexPrefix: "test", minReplicas: 0, maxReplicas: 3, frontendBaseUrl: testEmailFrontendBaseUrl, corsAllowedOrigins: ["https://orange-mud-00eed1803.1.azurestaticapps.net"]);
+var apiTest = AddApi("sheetmusic-api-test", testDb, searchIndexPrefix: "test", minReplicas: 0, maxReplicas: 3, frontendBaseUrl: testEmailFrontendBaseUrl);
 AddMigrationJob("sheetmusic-api-test-migrate", testDb);
 
 builder.Build().Run();

--- a/src/SheetMusic.AppHost/AppHost.cs
+++ b/src/SheetMusic.AppHost/AppHost.cs
@@ -100,7 +100,9 @@ builder.AddAzureContainerAppEnvironment("sheetmusic-aca-env")
 // from clobbering each other (issue #236) on the one shared Search service above. `minReplicas`/
 // `maxReplicas` are this app's real steady-state scale (see "Scale rules" above). `frontendBaseUrl` is
 // this app's own frontend deployment (test and prod are different URLs - see the parameters above).
-IResourceBuilder<ProjectResource> AddApi(string name, IResourceBuilder<IResourceWithConnectionString> database, string searchIndexPrefix, int minReplicas, int maxReplicas, IResourceBuilder<ParameterResource> frontendBaseUrl)
+// `corsAllowedOrigins` is this app's own set of browser origins - test and prod are served from
+// different frontend hosts, so each app declares only the origin(s) it actually needs.
+IResourceBuilder<ProjectResource> AddApi(string name, IResourceBuilder<IResourceWithConnectionString> database, string searchIndexPrefix, int minReplicas, int maxReplicas, IResourceBuilder<ParameterResource> frontendBaseUrl, string[] corsAllowedOrigins)
 {
     var minReplicasParameter = builder.AddParameter($"{name}-min-replicas", minReplicas.ToString());
     var maxReplicasParameter = builder.AddParameter($"{name}-max-replicas", maxReplicas.ToString());
@@ -135,6 +137,25 @@ IResourceBuilder<ProjectResource> AddApi(string name, IResourceBuilder<IResource
             // ACA does not infer probes from `WithHttpHealthCheck` the way local `aspire run`
             // health-checking does - both must be set explicitly here.
             app.Configuration.Ingress.TargetPort = 8080;
+
+            // ACA ingress-level CORS policy, declared here so it's part of the AppHost model and gets
+            // reapplied on every deploy - previously this had to be set by hand against the Container
+            // App resource (e.g. via the portal or `az containerapp ingress cors enable`), and Aspire's
+            // full-resource redeploy silently wiped it back to "no CORS policy" every time, since nothing
+            // in the deployment model declared it. Keep this in sync with AddSheetMusicSecurity's
+            // "AllowMember" policy (see Configuration/IServiceCollectionExtensions.cs). `corsAllowedOrigins`
+            // is this app's own real frontend origin(s) - test and prod intentionally do not share a list.
+            var corsPolicy = new ContainerAppCorsPolicy
+            {
+                AllowedMethods = { "*" },
+                AllowedHeaders = { "*" },
+                AllowCredentials = true,
+            };
+            foreach (var origin in corsAllowedOrigins)
+            {
+                corsPolicy.AllowedOrigins.Add(origin);
+            }
+            app.Configuration.Ingress.CorsPolicy = corsPolicy;
 
             var container = app.Template.Containers[0].Value!;
             container.Probes.Add(new ContainerAppProbe
@@ -204,10 +225,10 @@ void AddMigrationJob(string name, IResourceBuilder<IResourceWithConnectionString
         .PublishAsAzureContainerAppJob();
 }
 
-var api = AddApi("sheetmusic-api", db, searchIndexPrefix: "", minReplicas: 1, maxReplicas: 3, frontendBaseUrl: emailFrontendBaseUrl);
+var api = AddApi("sheetmusic-api", db, searchIndexPrefix: "", minReplicas: 1, maxReplicas: 3, frontendBaseUrl: emailFrontendBaseUrl, corsAllowedOrigins: ["https://medlem.stavanger-brassband.no"]);
 AddMigrationJob("sheetmusic-api-migrate", db);
 
-var apiTest = AddApi("sheetmusic-api-test", testDb, searchIndexPrefix: "test", minReplicas: 0, maxReplicas: 3, frontendBaseUrl: testEmailFrontendBaseUrl);
+var apiTest = AddApi("sheetmusic-api-test", testDb, searchIndexPrefix: "test", minReplicas: 0, maxReplicas: 3, frontendBaseUrl: testEmailFrontendBaseUrl, corsAllowedOrigins: ["https://orange-mud-00eed1803.1.azurestaticapps.net"]);
 AddMigrationJob("sheetmusic-api-test-migrate", testDb);
 
 builder.Build().Run();


### PR DESCRIPTION
## Problem
CORS was only enforced in ASP.NET Core middleware (`AllowMember` policy), and the origin list was stale/shared incorrectly between test and prod. On investigation, an ACA ingress-level CORS policy was initially added to make CORS part of the Aspire deployment model - but that risks **duplicate** `Access-Control-Allow-*` response headers if both layers are active (browsers treat duplicate/conflicting values as invalid and block the response), so that approach was reverted in favor of a single source of truth.

The real reason a platform-level CORS setting seemed necessary: `app.UseCors("AllowMember")` was registered *after* `UseAuthentication`/`UseAuthorization` in `Program.cs`, so 401/403 responses never got CORS headers from the app - the browser would report a generic CORS error instead of the real auth failure.

## Fix
- `Program.cs`: moved `UseCors` before `UseAuthentication`/`UseAuthorization` (the documented ASP.NET Core middleware ordering), so the app-level CORS policy now covers both successful and auth-failure responses in every environment.
- `IServiceCollectionExtensions.cs`: updated the `AllowMember` policy's origins - dropped the stale `sheetmusic-member.azurewebsites.net` origin, added the test frontend's real origin (`https://orange-mud-00eed1803.1.azurestaticapps.net`), kept prod's `https://medlem.stavanger-brassband.no` and localhost dev ports. Same binary serves both test and prod, so this is the union of both environments' real origins.
- `AppHost.cs`: reverted the ACA ingress-level `CorsPolicy` addition - no longer needed now that the app-level policy is correctly ordered and is the single enforcement point.
- `.github/agents/sheetmusic-dev.agent.md`: added guidance to use `aspire docs search`/`aspire docs api search` instead of reflecting over installed NuGet DLLs when investigating Aspire/Azure Provisioning APIs.
- Added `Tests/Shared/CorsTests.cs`: integration tests asserting CORS headers are present on a 401 response for an allowed origin, and absent for a disallowed origin - guards the middleware ordering fix.

## Verification
- `dotnet build` succeeds with 0 errors (pre-existing warnings only).
- `dotnet test` - all 339 tests pass, including the 2 new CORS tests.
