### PR TITLE
fix(users): detach connected musician before hard-deleting a user

### DIFF
--- a/src/SheetMusic.Api.Test/Users/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Users/UserTests.cs
@@ -728,6 +728,34 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
+    public async Task V2_DeleteUser_ShouldDetachConnectedMusician_WhenHardDeleting()
+    {
+        var anonymousClient = CreateV2Client();
+        var (id, _) = await RegisterInactiveUserAsync(anonymousClient, "hard-delete-musician");
+
+        Guid musicianId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            var musician = new Musician { Id = Guid.NewGuid(), ApplicationUserId = id };
+            db.Musicians.Add(musician);
+            await db.SaveChangesAsync();
+            musicianId = musician.Id;
+        }
+
+        var adminClient = CreateV2ClientWithTestToken(TestUser.Administrator);
+        var response = await adminClient.DeleteAsync($"users/{id}?hardDelete=true");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            var musician = await db.Musicians.SingleAsync(m => m.Id == musicianId);
+            musician.ApplicationUserId.Should().BeNull();
+        }
+    }
+
+    [Fact]
     public async Task V2_DeleteUser_ShouldBeForbidden_WhenNonAdmin()
     {
         var client = CreateV2ClientWithTestToken(TestUser.Testesen);

--- a/src/SheetMusic.Api/Users/Commands/DeleteUser.cs
+++ b/src/SheetMusic.Api/Users/Commands/DeleteUser.cs
@@ -1,5 +1,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Errors;
 using SheetMusic.Api.Users.Errors;
@@ -15,12 +17,15 @@ public class DeleteUser(Guid userId, bool hardDelete = false) : IRequest
     public Guid UserId { get; } = userId;
     public bool HardDelete { get; } = hardDelete;
 
-    public class Handler(UserManager<ApplicationUser> userManager) : IRequestHandler<DeleteUser>
+    public class Handler(UserManager<ApplicationUser> userManager, SheetMusicContext db) : IRequestHandler<DeleteUser>
     {
         public async Task Handle(DeleteUser request, CancellationToken cancellationToken)
         {
             var user = await userManager.FindByIdAsync(request.UserId.ToString())
                 ?? throw new NotFoundError($"users/{request.UserId}", "User not found");
+
+            if (request.HardDelete)
+                await DetachMusicianAsync(request.UserId, cancellationToken);
 
             var result = request.HardDelete
                 ? await userManager.DeleteAsync(user)
@@ -33,6 +38,16 @@ public class DeleteUser(Guid userId, bool hardDelete = false) : IRequest
             {
                 userToDeactivate.Inactive = true;
                 return await userManager.UpdateAsync(userToDeactivate);
+            }
+
+            async Task DetachMusicianAsync(Guid applicationUserId, CancellationToken ct)
+            {
+                var musician = await db.Musicians.SingleOrDefaultAsync(m => m.ApplicationUserId == applicationUserId, ct);
+                if (musician is null)
+                    return;
+
+                musician.ApplicationUserId = null;
+                await db.SaveChangesAsync(ct);
             }
         }
     }


### PR DESCRIPTION
## Problem
Deleting a user with hardDelete=true returned a 500 when a Musician record was linked to that user via Musicians.ApplicationUserId. UserManager.DeleteAsync deletes the AspNetUsers row directly, which conflicts with the FK_Musicians_AspNetUsers_ApplicationUserId constraint.

## Fix
DeleteUser.Handler now clears the musician-user connection (Musician.ApplicationUserId = null) before performing a hard delete. The musician record itself is preserved; only the link to the deleted user is removed. The soft-delete (deactivate) path is unchanged.

## Tests
Added V2_DeleteUser_ShouldDetachConnectedMusician_WhenHardDeleting, which links a Musician to a registered user, hard-deletes the user, and asserts the musician still exists with ApplicationUserId == null.