### PR TITLE
ci(deploy): run migrations before deploying new revision to avoid downtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,38 +76,11 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      # Deploy sequence, part 1 of 6 (issue #246, #234 decision 11): deploys the new image and creates
-      # the new revision with test's real replica counts (see AppHost.cs) - no scale trickery needed.
-      - name: Deploy test infrastructure and new image
-        run: aspire do provision-sheetmusic-api-test-containerapp --non-interactive
-        env:
-          Azure__SubscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          Azure__Location: ${{ vars.AZURE_LOCATION }}
-          Azure__ResourceGroup: ${{ vars.AZURE_RESOURCE_GROUP }}
-          Parameters__resend_api_key: ${{ secrets.RESEND_API_KEY }}
-          Parameters__email_from_address: ${{ vars.EMAIL_FROM_ADDRESS }}
-          Parameters__test_email_frontend_base_url: ${{ vars.EMAIL_FRONTEND_BASE_URL }}
-          Parameters__jwt_signing_key: ${{ secrets.JWT_SIGNING_KEY }}
-
-      # Deploy sequence, part 2 of 6: in Single revision mode the new revision above becomes active (and
-      # starts serving) as soon as it's healthy, so deactivate it immediately - before running
-      # migrations against not-yet-migrated code. `az containerapp revision deactivate`/`activate` (both
-      # GA) is used here rather than temporarily forcing min/max replicas to zero: Azure's own scale
-      # schema doesn't document a minimum value for maxReplicas, so that approach's validity was
-      # uncertain, whereas deactivate/activate is a purpose-built, documented mechanism for this exact
-      # "take a revision offline, then bring it back" scenario.
-      - name: Deactivate new test revision
-        run: |
-          set -euo pipefail
-          rg="${{ vars.AZURE_RESOURCE_GROUP }}"
-          revision=$(az containerapp show --name "sheetmusic-api-test" --resource-group "$rg" --query "properties.latestRevisionName" -o tsv)
-          echo "TEST_REVISION=$revision" >> "$GITHUB_ENV"
-          az containerapp revision deactivate --name "sheetmusic-api-test" --resource-group "$rg" --revision "$revision"
-
-      # Deploy sequence, part 3 of 6: the migration job is its own AppHost resource with its own
-      # provisioning step (`provision-sheetmusic-api-test-migrate-containerapp`), never touched by the
-      # containerapp step above - without this, the job silently keeps running its previous image/env vars
-      # (e.g. a stale connection string) on every deploy no matter what changed in the AppHost.
+      # Deploy sequence, part 1 of 4: the migration job is its own AppHost resource with its own
+      # provisioning step (`provision-sheetmusic-api-test-migrate-containerapp`) - deployed and run
+      # *before* the app's new revision below. Migrations now run against the still-serving old revision
+      # instead of a deactivated one: schema changes here are rarely breaking (accepted risk), so there's
+      # no need to take the app offline for the deploy window this used to require.
       - name: Deploy test migration job infrastructure and new image
         run: aspire do provision-sheetmusic-api-test-migrate-containerapp --non-interactive
         env:
@@ -119,7 +92,7 @@ jobs:
           Parameters__test_email_frontend_base_url: ${{ vars.EMAIL_FRONTEND_BASE_URL }}
           Parameters__jwt_signing_key: ${{ secrets.JWT_SIGNING_KEY }}
 
-      # Deploy sequence, part 4 of 6: start the test migration ACA Job. Container Apps/Jobs don't need
+      # Deploy sequence, part 2 of 4: start the test migration ACA Job. Container Apps/Jobs don't need
       # globally-unique names (unlike Storage/Search/ACR/SQL, which Aspire suffixes with a generated
       # hash) so the Azure resource name should match the AppHost resource name below exactly - verify
       # with `az containerapp job list` after the first deploy and adjust here if Aspire ever mangles it.
@@ -129,9 +102,9 @@ jobs:
             --name "sheetmusic-api-test-migrate" \
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}"
 
-      # Deploy sequence, part 5 of 6: poll the execution to completion and check its exit code (#234
-      # decision 11). Omitting this poll creates a race that only appears under a slow migration - the
-      # revision would reactivate (next step) before the schema is actually ready.
+      # Deploy sequence, part 3 of 4: poll the execution to completion and check its exit code. Omitting
+      # this poll creates a race that only appears under a slow migration - the new app revision (next
+      # step) would start serving on the new schema before it's actually ready.
       - name: Wait for test migration job to complete
         run: |
           set -euo pipefail
@@ -152,13 +125,21 @@ jobs:
           echo "Timed out waiting for migration job to complete"
           exit 1
 
-      # Deploy sequence, part 6 of 6: reactivate the revision now that the migration has succeeded.
-      - name: Reactivate test revision
-        run: |
-          az containerapp revision activate \
-            --name "sheetmusic-api-test" \
-            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --revision "${{ env.TEST_REVISION }}"
+      # Deploy sequence, part 4 of 4 (issue #246, #234 decision 11): deploys the new image and creates
+      # the new revision with test's real replica counts (see AppHost.cs) - no scale trickery needed. In
+      # Single revision mode this revision becomes active (and starts serving) as soon as it's healthy;
+      # since migrations already succeeded above, there's no deactivate/reactivate step and no downtime
+      # window.
+      - name: Deploy test infrastructure and new image
+        run: aspire do provision-sheetmusic-api-test-containerapp --non-interactive
+        env:
+          Azure__SubscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          Azure__Location: ${{ vars.AZURE_LOCATION }}
+          Azure__ResourceGroup: ${{ vars.AZURE_RESOURCE_GROUP }}
+          Parameters__resend_api_key: ${{ secrets.RESEND_API_KEY }}
+          Parameters__email_from_address: ${{ vars.EMAIL_FROM_ADDRESS }}
+          Parameters__test_email_frontend_base_url: ${{ vars.EMAIL_FRONTEND_BASE_URL }}
+          Parameters__jwt_signing_key: ${{ secrets.JWT_SIGNING_KEY }}
 
   deploy-prod:
     name: Deploy to production
@@ -203,31 +184,12 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy production infrastructure and new image
-        run: aspire do provision-sheetmusic-api-containerapp --non-interactive
-        env:
-          Azure__SubscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          Azure__Location: ${{ vars.AZURE_LOCATION }}
-          Azure__ResourceGroup: ${{ vars.AZURE_RESOURCE_GROUP }}
-          Parameters__resend_api_key: ${{ secrets.RESEND_API_KEY }}
-          Parameters__email_from_address: ${{ vars.EMAIL_FROM_ADDRESS }}
-          Parameters__email_frontend_base_url: ${{ vars.EMAIL_FRONTEND_BASE_URL }}
-          Parameters__jwt_signing_key: ${{ secrets.JWT_SIGNING_KEY }}
-
-      # See "Deactivate new test revision" above for why deactivate/activate is used instead of
-      # temporarily forcing min/max replicas to zero.
-      - name: Deactivate new production revision
-        run: |
-          set -euo pipefail
-          rg="${{ vars.AZURE_RESOURCE_GROUP }}"
-          revision=$(az containerapp show --name "sheetmusic-api" --resource-group "$rg" --query "properties.latestRevisionName" -o tsv)
-          echo "PROD_REVISION=$revision" >> "$GITHUB_ENV"
-          az containerapp revision deactivate --name "sheetmusic-api" --resource-group "$rg" --revision "$revision"
-
-      # The migration job is its own AppHost resource with its own provisioning step
-      # (`provision-sheetmusic-api-migrate-containerapp`), never touched by the containerapp step above -
-      # without this, the job silently keeps running its previous image/env vars (e.g. a stale connection
-      # string) on every deploy no matter what changed in the AppHost.
+      # See the equivalent test steps above for why migrations now run before the app's new revision is
+      # deployed, instead of deploy-then-deactivate-then-migrate-then-reactivate: the migration job is its
+      # own AppHost resource with its own provisioning step
+      # (`provision-sheetmusic-api-migrate-containerapp`) - without this, the job silently keeps running
+      # its previous image/env vars (e.g. a stale connection string) on every deploy no matter what
+      # changed in the AppHost.
       - name: Deploy production migration job infrastructure and new image
         run: aspire do provision-sheetmusic-api-migrate-containerapp --non-interactive
         env:
@@ -245,6 +207,8 @@ jobs:
             --name "sheetmusic-api-migrate" \
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}"
 
+      # Omitting this poll creates a race that only appears under a slow migration - the new app revision
+      # (next step) would start serving on the new schema before it's actually ready.
       - name: Wait for production migration job to complete
         run: |
           set -euo pipefail
@@ -265,9 +229,15 @@ jobs:
           echo "Timed out waiting for migration job to complete"
           exit 1
 
-      - name: Reactivate production revision
-        run: |
-          az containerapp revision activate \
-            --name "sheetmusic-api" \
-            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
-            --revision "${{ env.PROD_REVISION }}"
+      # Migrations already succeeded above, so the new revision goes live immediately - no
+      # deactivate/reactivate step and no downtime window.
+      - name: Deploy production infrastructure and new image
+        run: aspire do provision-sheetmusic-api-containerapp --non-interactive
+        env:
+          Azure__SubscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          Azure__Location: ${{ vars.AZURE_LOCATION }}
+          Azure__ResourceGroup: ${{ vars.AZURE_RESOURCE_GROUP }}
+          Parameters__resend_api_key: ${{ secrets.RESEND_API_KEY }}
+          Parameters__email_from_address: ${{ vars.EMAIL_FROM_ADDRESS }}
+          Parameters__email_frontend_base_url: ${{ vars.EMAIL_FRONTEND_BASE_URL }}
+          Parameters__jwt_signing_key: ${{ secrets.JWT_SIGNING_KEY }}


### PR DESCRIPTION
Deploy currently deploys the new app revision, deactivates it, runs the migration job, then reactivates the revision - the app is unreachable for that whole window on every deploy.

This reorders the sequence to deploy and run the migration job first (against the still-serving old revision), then deploy the app revision, which goes live immediately once healthy. No more deactivate/reactivate steps.

Accepted risk: a rare breaking schema change would run against the old revision momentarily before the new revision rolls out. We rarely make breaking SQL changes, so this is an acceptable tradeoff for removing the downtime window.