### PR TITLE
fix(auth): assume basic grant_type when omitted

### DIFF
--- a/src/SheetMusic.Api.Test/Users/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Users/UserTests.cs
@@ -194,6 +194,22 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
+    public async Task V2_GetToken_ShouldAssumeBasicGrantType_WhenGrantTypeIsOmitted()
+    {
+        var client = CreateV2Client();
+
+        var collection = new List<KeyValuePair<string?, string?>>
+        {
+            new("username", TestUser.Testesen.Email),
+            new("password", TestUser.Testesen.Password)
+        };
+
+        var content = new FormUrlEncodedContent(collection);
+        var response = await client.PostAsync("token", content);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task V2_GetToken_WithWrongPassword_ShouldReturnBadRequest()
     {
         var client = CreateV2Client();

--- a/src/SheetMusic.Api/Users/RequestModels/LoginRequest.cs
+++ b/src/SheetMusic.Api/Users/RequestModels/LoginRequest.cs
@@ -5,10 +5,17 @@ namespace SheetMusic.Api.Users.RequestModels;
 
 public class LoginRequest
 {
+    private string _grantType = "basic";
+
     /// <summary>
     /// The OAuth2 grant type. Either <c>"basic"</c> (username/password) or <c>"refresh_token"</c>.
+    /// Defaults to <c>"basic"</c> when omitted, since some OAuth2 clients (e.g. Scalar) cannot send it.
     /// </summary>
-    public string grant_type { get; set; } = null!;
+    public string grant_type
+    {
+        get => _grantType;
+        set => _grantType = string.IsNullOrWhiteSpace(value) ? "basic" : value;
+    }
 
     /// <summary>The account email address. Required when <see cref="grant_type"/> is <c>"basic"</c>.</summary>
     public string username { get; set; } = null!;
@@ -29,9 +36,7 @@ public class LoginRequest
         public Validator()
         {
             RuleFor(r => r.grant_type)
-                .NotEmpty().WithMessage("grant_type is required.")
-                .Must(g => SupportedGrantTypes.Contains(g)).WithMessage($"grant_type must be one of: {string.Join(", ", SupportedGrantTypes)}.")
-                .When(r => !string.IsNullOrEmpty(r.grant_type));
+                .Must(g => SupportedGrantTypes.Contains(g)).WithMessage($"grant_type must be one of: {string.Join(", ", SupportedGrantTypes)}.");
 
             // The "refresh_token" grant exchanges a refresh token for a new token pair and needs no
             // credentials. The "basic" grant (the legacy/password grant this API accepts) requires


### PR DESCRIPTION
## Problem

When no `grant_type` is sent on `POST token`, the request fails validation with a 400 (`grant_type must be one of: basic, refresh_token.`). Scalar's built-in OAuth2 UI does not support sending a `grant_type` form field, making the API's token endpoint unusable from Scalar's Try It panel.

## Fix

`LoginRequest.grant_type` now defaults to `"basic"` when the incoming value is null, empty, or whitespace (backing field + custom setter), instead of requiring the client to always send it. Requests that explicitly send an unsupported grant type (e.g. `client_credentials`) are still rejected by the validator.

## Tests

- Added `V2_GetToken_ShouldAssumeBasicGrantType_WhenGrantTypeIsOmitted`, asserting a token request with only username/password (no `grant_type`) succeeds.
- Existing grant_type tests (unsupported value, refresh_token, missing username) still pass.
