### PR TITLE
fix(auth): accept grant_type=password as alias for basic grant

### DIFF
--- a/src/SheetMusic.Api.Test/Users/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Users/UserTests.cs
@@ -210,6 +210,23 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
+    public async Task V2_GetToken_ShouldAssumeBasicGrantType_WhenGrantTypeIsPassword()
+    {
+        var client = CreateV2Client();
+
+        var collection = new List<KeyValuePair<string?, string?>>
+        {
+            new("grant_type", "password"),
+            new("username", TestUser.Testesen.Email),
+            new("password", TestUser.Testesen.Password)
+        };
+
+        var content = new FormUrlEncodedContent(collection);
+        var response = await client.PostAsync("token", content);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task V2_GetToken_WithWrongPassword_ShouldReturnBadRequest()
     {
         var client = CreateV2Client();

--- a/src/SheetMusic.Api/Users/RequestModels/LoginRequest.cs
+++ b/src/SheetMusic.Api/Users/RequestModels/LoginRequest.cs
@@ -9,12 +9,14 @@ public class LoginRequest
 
     /// <summary>
     /// The OAuth2 grant type. Either <c>"basic"</c> (username/password) or <c>"refresh_token"</c>.
-    /// Defaults to <c>"basic"</c> when omitted, since some OAuth2 clients (e.g. Scalar) cannot send it.
+    /// Defaults to <c>"basic"</c> when omitted, and also accepts the spec-correct <c>"password"</c>
+    /// value (RFC 6749 resource owner password credentials grant), since OAuth2 clients implementing
+    /// the documented password flow (e.g. Scalar) send <c>grant_type=password</c> rather than omitting it.
     /// </summary>
     public string grant_type
     {
         get => _grantType;
-        set => _grantType = string.IsNullOrWhiteSpace(value) ? "basic" : value;
+        set => _grantType = string.IsNullOrWhiteSpace(value) || value == "password" ? "basic" : value;
     }
 
     /// <summary>The account email address. Required when <see cref="grant_type"/> is <c>"basic"</c>.</summary>


### PR DESCRIPTION
## Problem
Requests to `POST /token` still returned `400` for OAuth2 clients that follow the documented password flow.

The `/token` endpoint advertises an OAuth2 **password** grant (see `OAuthSecuritySchemeTransformer`). Per RFC 6749, spec-conformant clients (e.g. Scalar) send `grant_type=password` explicitly rather than omitting the field. The prior fix (#280) only normalized a missing/blank `grant_type` to `"basic"`, so the spec-correct `"password"` value was still rejected by the `SupportedGrantTypes` check.

## Fix
`LoginRequest.grant_type` now normalizes `"password"` to `"basic"` in addition to missing/blank values, so both the omitted case and the standard OAuth2 `password` grant value are accepted.

## Testing
- Added `V2_GetToken_ShouldAssumeBasicGrantType_WhenGrantTypeIsPassword` covering `grant_type=password`.
- Ran `dotnet test --filter "FullyQualifiedName~V2_GetToken"` — all 11 tests pass.