### PR TITLE
fix(search): treat rebuild-index as idempotent when the index does not yet exist

### DIFF
--- a/src/SheetMusic.Api.Test/Search/IndexAdminServiceTests.cs
+++ b/src/SheetMusic.Api.Test/Search/IndexAdminServiceTests.cs
@@ -7,6 +7,8 @@ using SheetMusic.Api.Parts;
 using SheetMusic.Api.Search;
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace SheetMusic.Api.Test.Search;
@@ -34,6 +36,28 @@ public class IndexAdminServiceTests
         service.GetQueryClient<PartIndex>().IndexName.Should().Be("test-partindex");
     }
 
+    [Fact]
+    public async Task ClearIndexAsync_DoesNotThrow_WhenIndexDoesNotExist()
+    {
+        var searchIndexClient = new FailOnDeleteSearchIndexClient(404);
+        var service = new IndexAdminService(searchIndexClient, new ConfigurationBuilder().Build());
+
+        var act = () => service.ClearIndexAsync<PartIndex>();
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task ClearIndexAsync_Throws_WhenDeleteFailsForOtherReason()
+    {
+        var searchIndexClient = new FailOnDeleteSearchIndexClient(503);
+        var service = new IndexAdminService(searchIndexClient, new ConfigurationBuilder().Build());
+
+        var act = () => service.ClearIndexAsync<PartIndex>();
+
+        await act.Should().ThrowAsync<RequestFailedException>();
+    }
+
     private static IndexAdminService BuildService(string? indexPrefix = null)
     {
         var values = new Dictionary<string, string?>();
@@ -46,5 +70,18 @@ public class IndexAdminServiceTests
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
         var searchIndexClient = new SearchIndexClient(new Uri("https://example.search.windows.net"), new AzureKeyCredential("test-admin-key"));
         return new IndexAdminService(searchIndexClient, configuration);
+    }
+
+    /// <summary>
+    /// Simulates the Azure AI Search service's real behavior of returning a failure status from
+    /// delete-index, so <see cref="IndexAdminService.ClearIndexAsync{T}"/> can be verified to treat
+    /// 404 (index never created) as a no-op while still propagating other failures.
+    /// </summary>
+    private class FailOnDeleteSearchIndexClient(int status) : SearchIndexClient(new Uri("https://example.search.windows.net"), new AzureKeyCredential("test-admin-key"))
+    {
+        public override Task<Response> DeleteIndexAsync(string indexName, MatchConditions matchConditions = default, CancellationToken cancellationToken = default)
+        {
+            throw new RequestFailedException(status, "Delete index failed");
+        }
     }
 }

--- a/src/SheetMusic.Api/Search/IndexAdminService.cs
+++ b/src/SheetMusic.Api/Search/IndexAdminService.cs
@@ -28,7 +28,14 @@ public class IndexAdminService(SearchIndexClient searchIndexClient, IConfigurati
 
     public async Task ClearIndexAsync<T>()
     {
-        await searchIndexClient.DeleteIndexAsync(GetIndexName<T>(), default(MatchConditions));
+        try
+        {
+            await searchIndexClient.DeleteIndexAsync(GetIndexName<T>(), default(MatchConditions));
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            // Delete is meant to be idempotent; nothing to clear if the index was never created.
+        }
     }
 
     public SearchClient GetQueryClient<T>()


### PR DESCRIPTION
## Summary

The POST parts/index rebuild endpoint always calls IIndexAdminService.ClearIndexAsync first, which issues a delete-index request. Azure AI Search returns 404 when the index does not exist yet (e.g. the very first rebuild in a fresh environment), and the SDK throws RequestFailedException for that response, failing the whole rebuild with a 500 instead of behaving idempotently.

## Fix

IndexAdminService.ClearIndexAsync<T> now catches RequestFailedException with Status == 404 and treats it as a no-op, since there is nothing to clear if the index was never created. Other failures still propagate.

## Tests

Added to IndexAdminServiceTests:
- ClearIndexAsync_DoesNotThrow_WhenIndexDoesNotExist
- ClearIndexAsync_Throws_WhenDeleteFailsForOtherReason

Both use a SearchIndexClient subclass overriding the virtual DeleteIndexAsync to simulate service responses without a real Azure AI Search dependency.