### PR TITLE
fix(sets): validate title on set creation and persist recording url

### DIFF
--- a/src/SheetMusic.Api.Test/Sets/SetTests.cs
+++ b/src/SheetMusic.Api.Test/Sets/SetTests.cs
@@ -105,6 +105,33 @@ public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusi
     }
 
     [Fact]
+    public async Task AddNewSet_ShouldReturnBadRequest_WhenTitleIsMissing()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+
+        var response = await adminClient.PostAsJsonAsync("sheetmusic/sets", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddNewSet_ShouldPersistRecordingUrl()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+
+        var response = await adminClient.PostAsJsonAsync("sheetmusic/sets", new
+        {
+            Title = $"Set with recording - {Guid.NewGuid()}",
+            RecordingUrl = "https://example.com/recording.mp3"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var apiSet = await response.Content.ReadFromJsonAsync<ApiSet>(JsonDefaults.Options);
+        apiSet.Should().NotBeNull();
+        apiSet!.RecordingUrl.Should().Be("https://example.com/recording.mp3");
+    }
+
+    [Fact]
     public async Task GetSetList_ShouldBeSuccessfull()
     {
         var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);

--- a/src/SheetMusic.Api/Sets/Commands/AddSet.cs
+++ b/src/SheetMusic.Api/Sets/Commands/AddSet.cs
@@ -36,6 +36,7 @@ public class AddSet(SetRequest input) : IRequest
                 Arranger = input.Arranger,
                 SoleSellingAgent = input.SoleSellingAgent,
                 MissingParts = input.MissingParts,
+                RecordingUrl = input.RecordingUrl,
                 BorrowedFrom = input.BorrowedFrom,
                 BorrowedDateTime = string.IsNullOrEmpty(input.BorrowedFrom) ? null : (DateTimeOffset?)DateTimeOffset.Now
             };

--- a/src/SheetMusic.Api/Sets/RequestModels/SetRequest.cs
+++ b/src/SheetMusic.Api/Sets/RequestModels/SetRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace SheetMusic.Api.Sets.RequestModels;
+﻿using FluentValidation;
+
+namespace SheetMusic.Api.Sets.RequestModels;
 
 public class SetRequest
 {
@@ -10,4 +12,16 @@ public class SetRequest
     public string? SoleSellingAgent { get; set; } = null!;
     public string? MissingParts { get; set; } = null!;
     public string? BorrowedFrom { get; set; }
+
+    public class Validator : AbstractValidator<SetRequest>
+    {
+        public Validator()
+        {
+            RuleFor(s => s.Title).NotEmpty().WithMessage("Title is required");
+            RuleFor(s => s.ArchiveNumber)
+                .GreaterThanOrEqualTo(1)
+                .When(s => s.ArchiveNumber.HasValue)
+                .WithMessage("ArchiveNumber must be a positive number");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- `POST /sheetmusic/sets` returned a **500 Internal Server Error** instead of a 400 when required fields (e.g. `Title`) were missing. `SetRequest` had no FluentValidation validator, so an empty/invalid request body flowed through to `AddSet.Handler`, which then failed in EF Core when saving a set with a null `Title`.
- `AddSet.Handler` also silently dropped `RecordingUrl` when creating a new set, even though it's accepted on the request and persisted correctly on update.

## Changes
- Added a `Validator` to `SetRequest` requiring `Title` and validating `ArchiveNumber >= 1` when supplied.
- `AddSet.Handler` now persists `RecordingUrl` on creation.
- Added tests: `AddNewSet_ShouldReturnBadRequest_WhenTitleIsMissing`, `AddNewSet_ShouldPersistRecordingUrl`.

## Testing
- Found via exploratory testing of the deployed test environment (creating a new set via "Nytt notesett" in the frontend triggered the 500).
- `dotnet test` on `SheetMusic.Api.Test/Sets/SetTests.cs`: 38 passed.
