### PR TITLE
fix(database): retry transient SQL failures and stop prod free-limit auto-pause

### DIFF
--- a/src/SheetMusic.Api/Program.cs
+++ b/src/SheetMusic.Api/Program.cs
@@ -20,7 +20,10 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 
 builder.Services.AddDbContext<SheetMusicContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("SheetMusicContext")));
+    options.UseSqlServer(builder.Configuration.GetConnectionString("SheetMusicContext"), sqlOptions =>
+        // General resiliency against transient connection failures (timeouts, throttling) - not tied to
+        // any specific diagnosis, EF Core just retries these instead of failing the first request.
+        sqlOptions.EnableRetryOnFailure(maxRetryCount: 5, maxRetryDelay: TimeSpan.FromSeconds(10), errorNumbersToAdd: null)));
 
 builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>(options =>
     {

--- a/src/SheetMusic.AppHost/AppHost.cs
+++ b/src/SheetMusic.AppHost/AppHost.cs
@@ -1,7 +1,9 @@
+using Azure.Provisioning;
 using Azure.Provisioning.AppContainers;
 using Azure.Provisioning.ContainerRegistry;
 using Azure.Provisioning.OperationalInsights;
 using Azure.Provisioning.Search;
+using Azure.Provisioning.Sql;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -21,6 +23,23 @@ var sql = builder.AddAzureSqlServer("sql")
 // once. Test keeps its own database so its data never touches production's.
 var db = sql.AddDatabase("SheetMusicContext");
 var testDb = sql.AddDatabase("SheetMusicContextTest");
+
+// Prod must stay online for real users, so both of the free offer's independent pause triggers are
+// disabled here: idle-based auto-pause (AutoPauseDelay) and, separately, the auto-pause Aspire enables by
+// default once the monthly free quota (100,000 vCore-seconds or 32 GB) is exhausted
+// (FreeLimitExhaustionBehavior) - prod instead bills for any overage rather than pausing. Test keeps both
+// defaults so it can idle down / stay paused once its own free quota runs out. AzureSqlDatabaseResource
+// itself doesn't support ConfigureInfrastructure (it isn't an AzureProvisioningResource) - only the parent
+// server resource does - so the prod database's generated SqlDatabase is picked out of the shared server's
+// bicep resources by its BicepIdentifier, the same normalized name Aspire itself assigns each database
+// from its resource key.
+sql.ConfigureInfrastructure(infrastructure =>
+{
+    var prodDatabase = infrastructure.GetProvisionableResources().OfType<SqlDatabase>()
+        .Single(database => database.BicepIdentifier == Infrastructure.NormalizeBicepIdentifier("SheetMusicContext"));
+    prodDatabase.AutoPauseDelay = -1;
+    prodDatabase.FreeLimitExhaustionBehavior = FreeLimitExhaustionBehavior.BillOverUsage;
+});
 
 var storage = builder.AddAzureStorage("storage")
     .RunAsEmulator(emulator => emulator


### PR DESCRIPTION
## Summary
Investigated intermittent Connection Timeout Expired errors from EF Core against Azure SQL. Two changes:

1. **EF Core retry policy** ([Program.cs](src/SheetMusic.Api/Program.cs)): EnableRetryOnFailure so transient connection errors (timeouts, throttling) are retried instead of failing the first request.
2. **Prod free-offer auto-pause gap** ([AppHost.cs](src/SheetMusic.AppHost/AppHost.cs)): prod's SQL database already disabled idle-based auto-pause (AutoPauseDelay = -1), but Aspire defaults every free-SKU database to FreeLimitExhaustionBehavior.AutoPause too - a *separate* trigger that would pause prod once the monthly free vCore-second/storage quota is exhausted, independent of idle time. Prod now sets BillOverUsage instead. Test is untouched (still auto-pauses on both idle and quota exhaustion, by design).

## Investigation notes
Checked live Azure Monitor metrics and activity logs for both databases:
- Test db: idle auto-pause/resume cycling as expected, no impact on prod.
- Prod db: no pause/resume events at all in the observed window. A handful of isolated connection_failed blips coincided with small serverless vCore-scaling bumps (not a pause) - consistent with normal, low-frequency serverless auto-scaling behavior rather than a free-tier-specific issue. Low enough volume that the new retry policy should absorb it.

## Testing
- \dotnet build\ on the full solution - no new warnings/errors.
- No behavior change reachable from existing integration tests (they run against \UseInMemoryDatabase\, unaffected by either change).