### PR TITLE
fix(apphost): switch prod SQL database to Basic tier

### DIFF
--- a/src/SheetMusic.AppHost/AppHost.cs
+++ b/src/SheetMusic.AppHost/AppHost.cs
@@ -21,24 +21,24 @@ var sql = builder.AddAzureSqlServer("sql")
 // invocations, so genuinely shared resources (this server, Search, the ACA environment, the registry,
 // Log Analytics) no longer need hand-created "existing" workarounds - each one is simply provisioned
 // once. Test keeps its own database so its data never touches production's.
-var db = sql.AddDatabase("SheetMusicContext");
+// Prod opts out of the free-limit SKU (issue: prod kept auto-pausing every 30-90 min in production even
+// with AutoPauseDelay=-1 and FreeLimitExhaustionBehavior=BillOverUsage - confirmed via Azure Monitor that
+// the free-limit SKU (UseFreeLimit) forces auto-pause capability regardless of those settings). Prod is
+// now a normal pay-as-you-go serverless database instead, which properly honors AutoPauseDelay. Test
+// keeps the free-limit SKU and its default auto-pause so it can idle down when unused.
+var db = sql.AddDatabase("SheetMusicContext")
+    .WithDefaultAzureSku();
 var testDb = sql.AddDatabase("SheetMusicContextTest");
 
-// Prod must stay online for real users, so both of the free offer's independent pause triggers are
-// disabled here: idle-based auto-pause (AutoPauseDelay) and, separately, the auto-pause Aspire enables by
-// default once the monthly free quota (100,000 vCore-seconds or 32 GB) is exhausted
-// (FreeLimitExhaustionBehavior) - prod instead bills for any overage rather than pausing. Test keeps both
-// defaults so it can idle down / stay paused once its own free quota runs out. AzureSqlDatabaseResource
-// itself doesn't support ConfigureInfrastructure (it isn't an AzureProvisioningResource) - only the parent
-// server resource does - so the prod database's generated SqlDatabase is picked out of the shared server's
-// bicep resources by its BicepIdentifier, the same normalized name Aspire itself assigns each database
-// from its resource key.
+// Prod must stay online for real users. AzureSqlDatabaseResource itself doesn't support
+// ConfigureInfrastructure (it isn't an AzureProvisioningResource) - only the parent server resource does
+// - so the prod database's generated SqlDatabase is picked out of the shared server's bicep resources by
+// its BicepIdentifier, the same normalized name Aspire itself assigns each database from its resource key.
 sql.ConfigureInfrastructure(infrastructure =>
 {
     var prodDatabase = infrastructure.GetProvisionableResources().OfType<SqlDatabase>()
         .Single(database => database.BicepIdentifier == Infrastructure.NormalizeBicepIdentifier("SheetMusicContext"));
     prodDatabase.AutoPauseDelay = -1;
-    prodDatabase.FreeLimitExhaustionBehavior = FreeLimitExhaustionBehavior.BillOverUsage;
 });
 
 var storage = builder.AddAzureStorage("storage")

--- a/src/SheetMusic.AppHost/AppHost.cs
+++ b/src/SheetMusic.AppHost/AppHost.cs
@@ -21,24 +21,26 @@ var sql = builder.AddAzureSqlServer("sql")
 // invocations, so genuinely shared resources (this server, Search, the ACA environment, the registry,
 // Log Analytics) no longer need hand-created "existing" workarounds - each one is simply provisioned
 // once. Test keeps its own database so its data never touches production's.
-// Prod opts out of the free-limit SKU (issue: prod kept auto-pausing every 30-90 min in production even
-// with AutoPauseDelay=-1 and FreeLimitExhaustionBehavior=BillOverUsage - confirmed via Azure Monitor that
-// the free-limit SKU (UseFreeLimit) forces auto-pause capability regardless of those settings). Prod is
-// now a normal pay-as-you-go serverless database instead, which properly honors AutoPauseDelay. Test
-// keeps the free-limit SKU and its default auto-pause so it can idle down when unused.
-var db = sql.AddDatabase("SheetMusicContext")
-    .WithDefaultAzureSku();
+var db = sql.AddDatabase("SheetMusicContext");
 var testDb = sql.AddDatabase("SheetMusicContextTest");
 
-// Prod must stay online for real users. AzureSqlDatabaseResource itself doesn't support
+// Prod runs on the Basic tier - matching the pre-Aspire database (sheetmusicv4) - instead of the
+// free-limit serverless SKU Aspire assigns by default. The free-limit SKU (UseFreeLimit) kept
+// auto-pausing prod every 30-90 min in production even with AutoPauseDelay=-1 and
+// FreeLimitExhaustionBehavior=BillOverUsage set (confirmed via Azure Monitor - it forces auto-pause
+// capability regardless of those settings). An always-on serverless tier would avoid that but cost
+// ~$195+/month at its 0.5 vCore floor; Basic is DTU-provisioned, so it has no auto-pause capability at
+// all, at close to the old database's cost (~$5/month). AzureSqlDatabaseResource itself doesn't support
 // ConfigureInfrastructure (it isn't an AzureProvisioningResource) - only the parent server resource does
 // - so the prod database's generated SqlDatabase is picked out of the shared server's bicep resources by
 // its BicepIdentifier, the same normalized name Aspire itself assigns each database from its resource key.
+// Test keeps the default free-limit SKU and its auto-pause so it can idle down when unused.
 sql.ConfigureInfrastructure(infrastructure =>
 {
     var prodDatabase = infrastructure.GetProvisionableResources().OfType<SqlDatabase>()
         .Single(database => database.BicepIdentifier == Infrastructure.NormalizeBicepIdentifier("SheetMusicContext"));
-    prodDatabase.AutoPauseDelay = -1;
+    prodDatabase.Sku = new SqlSku { Name = "Basic", Tier = "Basic" };
+    prodDatabase.UseFreeLimit = false;
 });
 
 var storage = builder.AddAzureStorage("storage")


### PR DESCRIPTION
## Problem

Prod's SheetMusicContext Azure SQL database kept auto-pausing every 30-90 minutes in production, causing the first request after a pause to fail with Connection Timeout Expired, even after PR #296 set AutoPauseDelay = -1 and FreeLimitExhaustionBehavior = BillOverUsage.

## Root cause

Confirmed via Azure Monitor activity log: the pause/resume operations on the prod database resource are **system-triggered** (empty caller field) on a cadence matching classic idle-based auto-pause, despite the config explicitly disabling both known pause triggers. The free-limit SKU (UseFreeLimit) appears to force auto-pause capability regardless of AutoPauseDelay/FreeLimitExhaustionBehavior.

## Fix

Initially considered WithDefaultAzureSku() (always-on GP Serverless), but that would cost ~\-250/month since prod can never auto-pause and is always billed for at least its 0.5 vCore floor - a huge jump from the ~\/month the pre-Aspire database (sheetmusicv4, Basic tier) cost.

Instead, prod now explicitly sets its SKU to **Basic** (5 DTU, matching the old database) and UseFreeLimit = false. Basic is DTU-provisioned rather than serverless, so it has no auto-pause capability at all - this avoids the free-limit SKU bug at its root instead of paying for an always-on serverless floor. Test is unchanged (keeps the free-limit serverless SKU + default auto-pause, since it should idle down when unused). Current prod data size is ~12 MB, well within Basic's 2 GB cap.

## Cost impact

Prod moves from the free monthly allowance to Basic tier's flat ~\.90/month (\.161/day) - in line with the pre-Aspire database's cost, and far cheaper than an always-on serverless tier.

## Verification plan

After deploy, monitor z monitor activity-log list for the prod database resource over the next 24-48h to confirm no further pause/resume events.