### PR TITLE
fix(projects): apply \ filter on GET /projects

### DIFF
--- a/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
@@ -724,4 +724,52 @@ public class ProjectTests(SheetMusicWebAppFactory factory) : IClassFixture<Sheet
     }
 
     #endregion
+
+    #region OData $search
+
+    [Fact]
+    public async Task GetProjects_WithSearchOnName_ShouldReturnMatchingProjects()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedProjectsAsync(client, "Oppstart 2026", "Konsert 2026", "Sommerfest");
+
+        var response = await client.GetAsync($"projects?$search={Uri.EscapeDataString("Oppstart")}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var projects = await response.Content.ReadFromJsonAsync<List<ApiProject>>(JsonDefaults.Options);
+        projects.Should().ContainSingle();
+        projects![0].Name.Should().Be("Oppstart 2026");
+    }
+
+    [Fact]
+    public async Task GetProjects_WithSearchOnName_ShouldReturnEmptyArray_WhenNoMatches()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedProjectsAsync(client, "Oppstart 2026", "Konsert 2026");
+
+        var response = await client.GetAsync($"projects?$search={Uri.EscapeDataString("no-project-will-match-this")}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var projects = await response.Content.ReadFromJsonAsync<List<ApiProject>>(JsonDefaults.Options);
+        projects.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetProjects_WithSearchAndFilter_ShouldApplyBoth()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Administrator);
+        await SeedProjectsAsync(client, "Oppstart 2026", "Oppstart 2027", "Konsert 2026");
+
+        var response = await client.GetAsync($"projects?$search={Uri.EscapeDataString("Oppstart")}&$filter={Uri.EscapeDataString("name eq 'Oppstart 2027'")}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var projects = await response.Content.ReadFromJsonAsync<List<ApiProject>>(JsonDefaults.Options);
+        projects.Should().ContainSingle();
+        projects![0].Name.Should().Be("Oppstart 2027");
+    }
+
+    #endregion
 }

--- a/src/SheetMusic.Api/Projects/Queries/GetProjectCollection.cs
+++ b/src/SheetMusic.Api/Projects/Queries/GetProjectCollection.cs
@@ -34,6 +34,12 @@ public class GetProjectCollection(ODataQueryParams? queryParams) : IRequest<List
             if (request.QueryParams != null && request.QueryParams.HasFilter)
                 query = query.ApplyODataFilters(request.QueryParams, FieldMapping);
 
+            if (request.QueryParams != null && request.QueryParams.HasSearch)
+            {
+                var term = request.QueryParams.Search ?? "";
+                query = query.Where(p => p.Name.Contains(term));
+            }
+
             if (request.QueryParams != null && request.QueryParams.OrderBy.Any())
                 query = query.ApplyODataOrderBy(request.QueryParams, FieldMapping);
 


### PR DESCRIPTION
Fixes #302

GET /projects accepted a \ query parameter but silently ignored it — all projects were returned regardless of the search term.

## Root cause

GetProjectCollection.Handler only checked HasFilter and OrderBy; it never evaluated HasSearch.

## Fix

Added a Where(p => p.Name.Contains(term)) predicate when HasSearch is true, mirroring the pattern already used in GetSets.

## Tests

Added three integration tests covering:
- Search matches by name
- Search with no matches returns empty array
- \ and \ are applied together (AND semantics)