### PR TITLE
fix(foundry): deploy model in Sweden Central

### DIFF
--- a/src/SheetMusic.AppHost/AppHost.cs
+++ b/src/SheetMusic.AppHost/AppHost.cs
@@ -1,6 +1,8 @@
 using Azure.Provisioning;
+using Azure.Core;
 using Azure.Provisioning.AppContainers;
 using Azure.Provisioning.ContainerRegistry;
+using Azure.Provisioning.CognitiveServices;
 using Azure.Provisioning.OperationalInsights;
 using Azure.Provisioning.Search;
 using Azure.Provisioning.Sql;
@@ -89,7 +91,12 @@ var search = builder.AddAzureSearch("search")
 // One shared Foundry account with isolated production and test deployments. Both use the same
 // model so local and test classification behavior stays representative of production; separate
 // capacities prevent a developer loop or backfill test from consuming production TPM quota.
-var foundry = builder.AddFoundry("foundry");
+var foundry = builder.AddFoundry("foundry")
+    .ConfigureInfrastructure(infrastructure =>
+    {
+        var account = infrastructure.GetProvisionableResources().OfType<CognitiveServicesAccount>().Single();
+        account.Location = new AzureLocation("swedencentral");
+    });
 var chat = foundry.AddDeployment("chat", FoundryModel.OpenAI.Gpt5Mini)
     .WithProperties(deployment => deployment.SkuCapacity = 1);
 var chatTest = foundry.AddDeployment("chat-test", FoundryModel.OpenAI.Gpt5Mini)


### PR DESCRIPTION
## Summary

- Configure only the Microsoft Foundry Cognitive Services account to deploy in `swedencentral`.
- Leave the remaining Azure resources on their existing location configuration.

## Validation

- `dotnet build src/SheetMusic.AppHost/SheetMusic.AppHost.csproj --no-restore`
- Code review completed with no issues.