### PR TITLE
feat(auth): enforce music catalog access scopes

### DIFF
--- a/src/SheetMusic.Api.Test/Infrastructure/Authentication/TestUser.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/Authentication/TestUser.cs
@@ -33,11 +33,29 @@ public class TestUser
         IsAdministrator = false
     };
 
+    public static TestUser Musikant => new TestUser
+    {
+        Identifier = Guid.Parse("D1E3F2B8-9F5B-4DFA-A812-2D946C7C1D59"),
+        Name = "Mina Musikant",
+        Email = "mina@musikant.com",
+        Password = "IntgTest123!",
+        IsAdministrator = false
+    };
+
     public static TestUser Noteansvarlig => new TestUser
     {
         Identifier = Guid.Parse("6E0A1B6C-6C1D-4B0E-9A2F-3F1D2C4B5A67"),
         Name = "Nora Noteansvarlig",
         Email = "nora@noteansvarlig.com",
+        Password = "IntgTest123!",
+        IsAdministrator = false
+    };
+
+    public static TestUser Arkivleser => new TestUser
+    {
+        Identifier = Guid.Parse("C4BFB27F-0FAF-4EA2-A0E8-5257052C3E13"),
+        Name = "Arne Arkivleser",
+        Email = "arne@arkivleser.com",
         Password = "IntgTest123!",
         IsAdministrator = false
     };

--- a/src/SheetMusic.Api.Test/Infrastructure/SheetMusicWebAppFactory.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/SheetMusicWebAppFactory.cs
@@ -127,10 +127,15 @@ public class SheetMusicWebAppFactory : WebApplicationFactory<Program>
         roleManager.CreateAsync(new IdentityRole<Guid> { Name = Roles.Admin }).GetAwaiter().GetResult();
         roleManager.CreateAsync(new IdentityRole<Guid> { Name = Roles.Noteansvarlig }).GetAwaiter().GetResult();
         roleManager.CreateAsync(new IdentityRole<Guid> { Name = Roles.Musikant }).GetAwaiter().GetResult();
+        roleManager.CreateAsync(new IdentityRole<Guid> { Name = Roles.Arkivleser }).GetAwaiter().GetResult();
         roleManager.CreateAsync(new IdentityRole<Guid> { Name = Roles.Prosjektleder }).GetAwaiter().GetResult();
 
         SeedUser(userManager, db, TestUser.Testesen, Roles.Musikant);
+        var testesen = userManager.FindByIdAsync(TestUser.Testesen.Identifier.ToString()).GetAwaiter().GetResult();
+        userManager.AddToRoleAsync(testesen!, Roles.Arkivleser).GetAwaiter().GetResult();
+        SeedUser(userManager, db, TestUser.Musikant, Roles.Musikant);
         SeedUser(userManager, db, TestUser.Noteansvarlig, Roles.Noteansvarlig);
+        SeedUser(userManager, db, TestUser.Arkivleser, Roles.Arkivleser);
         SeedUser(userManager, db, TestUser.Administrator, Roles.Admin);
         SeedUser(userManager, db, TestUser.Prosjektleder, Roles.Prosjektleder);
 

--- a/src/SheetMusic.Api.Test/Sets/SetTests.cs
+++ b/src/SheetMusic.Api.Test/Sets/SetTests.cs
@@ -308,8 +308,27 @@ public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusi
 
         var token = await GetDownloadTokenAsync(testSet);
 
-        var response = await adminClient.GetAsync($"sheetmusic/sets/{testSet.Title}/parts/{part.Name}/pdf?downloadToken={token}");
+        var anonymousClient = factory.CreateClient();
+        var response = await anonymousClient.GetAsync($"sheetmusic/sets/{testSet.Title}/parts/{part.Name}/pdf?downloadToken={token}");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await anonymousClient.GetAsync($"sheetmusic/sets/{testSet.Title}/parts/{part.Name}/pdf?downloadToken={token}"))
+            .StatusCode.Should().NotBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetPartsAsZip_ShouldAllowEachIssuedTokenToBeUsedOnce()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var testSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        var otherSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        var firstToken = await GetDownloadTokenAsync(testSet);
+        var secondToken = await GetDownloadTokenAsync(testSet);
+        var anonymousClient = factory.CreateClient();
+
+        (await anonymousClient.GetAsync($"sheetmusic/sets/{otherSet.Id}/zip?downloadToken={firstToken}")).StatusCode.Should().NotBe(HttpStatusCode.OK);
+        (await anonymousClient.GetAsync($"sheetmusic/sets/{testSet.Id}/zip?downloadToken={firstToken}")).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await anonymousClient.GetAsync($"sheetmusic/sets/{testSet.Id}/zip?downloadToken={firstToken}")).StatusCode.Should().NotBe(HttpStatusCode.OK);
+        (await anonymousClient.GetAsync($"sheetmusic/sets/{testSet.Id}/zip?downloadToken={secondToken}")).StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
@@ -499,7 +518,7 @@ public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusi
         var tokenResponse = await adminClient.GetAsync($"sheetmusic/sets/{set.Id}/zip/token");
         var body = await tokenResponse.Content.ReadAsStringAsync();
 
-        return body;
+        return body.Trim('"');
     }
 
     private async Task UploadPartsAsync(List<ApiPart> parts, ApiSet set)

--- a/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
@@ -132,6 +132,67 @@ public class ProjectTests(SheetMusicWebAppFactory factory) : IClassFixture<Sheet
     }
 
     [Fact]
+    public async Task GetCatalogResources_ShouldRespectActiveProjectScope_ForMusikantAndArkivleser()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var activeProject = new
+        {
+            Name = $"Active project - {Guid.NewGuid():N}",
+            StartDate = DateTimeOffset.UtcNow.AddDays(-1),
+            EndDate = DateTimeOffset.UtcNow.AddDays(1)
+        };
+        var inactiveProject = new
+        {
+            Name = $"Inactive project - {Guid.NewGuid():N}",
+            StartDate = DateTimeOffset.UtcNow.AddDays(-3),
+            EndDate = DateTimeOffset.UtcNow.AddDays(-2)
+        };
+        await adminClient.PostAsJsonAsync("projects", activeProject);
+        await adminClient.PostAsJsonAsync("projects", inactiveProject);
+
+        var activeSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        var inactiveSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        await adminClient.PostAsJsonAsync($"projects/{activeProject.Name}/sets", new { SetIdentifiers = new[] { activeSet.Id.ToString() } });
+        await adminClient.PostAsJsonAsync($"projects/{inactiveProject.Name}/sets", new { SetIdentifiers = new[] { inactiveSet.Id.ToString() } });
+
+        var musikantClient = factory.CreateClientWithTestToken(TestUser.Musikant);
+        var musikantProjects = await musikantClient.GetFromJsonAsync<List<ApiProject>>("projects", JsonDefaults.Options);
+        musikantProjects!.Should().Contain(project => project.Name == activeProject.Name);
+        musikantProjects.Should().NotContain(project => project.Name == inactiveProject.Name);
+        var musikantSets = await musikantClient.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets", JsonDefaults.Options);
+        musikantSets!.Should().Contain(set => set.Id == activeSet.Id);
+        musikantSets.Should().NotContain(set => set.Id == inactiveSet.Id);
+        (await musikantClient.GetAsync($"sheetmusic/sets/{inactiveSet.Id}")).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        (await musikantClient.GetAsync($"sheetmusic/sets/{inactiveSet.Id}/zip/token")).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var activeTokenResponse = await musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip/token");
+        activeTokenResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var activeToken = await activeTokenResponse.Content.ReadAsStringAsync();
+        (await musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip?downloadToken={activeToken.Trim('"')}"))
+            .StatusCode.Should().Be(HttpStatusCode.OK);
+        var concurrentToken = (await (await musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip/token")).Content.ReadAsStringAsync()).Trim('"');
+        var concurrentDownloads = await Task.WhenAll(
+            musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip?downloadToken={concurrentToken}"),
+            musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip?downloadToken={concurrentToken}"));
+        concurrentDownloads.Should().ContainSingle(response => response.StatusCode == HttpStatusCode.OK);
+
+        var arkivleserClient = factory.CreateClientWithTestToken(TestUser.Arkivleser);
+        var arkivleserProjects = await arkivleserClient.GetFromJsonAsync<List<ApiProject>>("projects", JsonDefaults.Options);
+        arkivleserProjects!.Should().Contain(project => project.Name == inactiveProject.Name);
+        var arkivleserSets = await arkivleserClient.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets", JsonDefaults.Options);
+        arkivleserSets!.Should().Contain(set => set.Id == inactiveSet.Id);
+        (await arkivleserClient.GetAsync($"sheetmusic/sets/{inactiveSet.Id}")).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await arkivleserClient.GetAsync($"sheetmusic/sets/{inactiveSet.Id}/zip/token")).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var administratorSets = await adminClient.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets", JsonDefaults.Options);
+        administratorSets!.Should().Contain(set => set.Id == inactiveSet.Id);
+        var dualRoleClient = factory.CreateClientWithTestToken(TestUser.Testesen);
+        (await dualRoleClient.GetAsync($"sheetmusic/sets/{inactiveSet.Id}")).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var noCatalogAccessClient = factory.CreateClientWithTestToken(TestUser.Prosjektleder);
+        (await noCatalogAccessClient.GetAsync($"sheetmusic/sets/{activeSet.Id}")).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
     public async Task GetProjects_ShouldReturn401_WhenUnauthenticated()
     {
         var client = factory.CreateClient();

--- a/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
@@ -167,12 +167,13 @@ public class ProjectTests(SheetMusicWebAppFactory factory) : IClassFixture<Sheet
         var activeTokenResponse = await musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip/token");
         activeTokenResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var activeToken = await activeTokenResponse.Content.ReadAsStringAsync();
-        (await musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip?downloadToken={activeToken.Trim('"')}"))
+        var anonymousClient = factory.CreateClient();
+        (await anonymousClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip?downloadToken={activeToken.Trim('"')}"))
             .StatusCode.Should().Be(HttpStatusCode.OK);
         var concurrentToken = (await (await musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip/token")).Content.ReadAsStringAsync()).Trim('"');
         var concurrentDownloads = await Task.WhenAll(
-            musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip?downloadToken={concurrentToken}"),
-            musikantClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip?downloadToken={concurrentToken}"));
+            anonymousClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip?downloadToken={concurrentToken}"),
+            anonymousClient.GetAsync($"sheetmusic/sets/{activeSet.Id}/zip?downloadToken={concurrentToken}"));
         concurrentDownloads.Should().ContainSingle(response => response.StatusCode == HttpStatusCode.OK);
 
         var arkivleserClient = factory.CreateClientWithTestToken(TestUser.Arkivleser);

--- a/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
+++ b/src/SheetMusic.Api/Configuration/IServiceCollectionExtensions.cs
@@ -182,7 +182,9 @@ public static class IServiceCollectionExtensions
             options.AddPolicy(AuthPolicy.ManageMusic, policy => policy.RequireRole(Roles.Admin, Roles.Noteansvarlig));
             options.AddPolicy(AuthPolicy.ManageProjects, policy => policy.RequireRole(Roles.Admin, Roles.Noteansvarlig, Roles.Prosjektleder));
         });
+        services.AddHttpContextAccessor();
         services.AddScoped<AuthResolver>();
+        services.AddScoped<CatalogAccessService>();
 
         return services;
     }

--- a/src/SheetMusic.Api/Projects/ProjectsController.cs
+++ b/src/SheetMusic.Api/Projects/ProjectsController.cs
@@ -25,7 +25,7 @@ namespace SheetMusic.Api.Projects;
 /// </summary>
 [Authorize]
 [ApiController]
-public class ProjectsController(IMediator mediator) : ControllerBase
+public class ProjectsController(IMediator mediator, CatalogAccessService catalogAccess) : ControllerBase
 {
     /// <summary>
     /// Gets a list of all projects. OData filtering is supported, e.g. $filter=name eq 'Christmas concert'.
@@ -38,7 +38,7 @@ public class ProjectsController(IMediator mediator) : ControllerBase
     {
         var projects = await mediator.Send(new GetProjectCollection(query));
 
-        return projects.Select(p => new ApiProject(p)).ToList();
+        return projects.Where(project => catalogAccess.CanAccessProject(project.StartDate, project.EndDate)).Select(p => new ApiProject(p)).ToList();
     }
 
     /// <summary>
@@ -52,6 +52,9 @@ public class ProjectsController(IMediator mediator) : ControllerBase
     public async Task<ActionResult<ApiProject>> GetProject(string projectIdentifier)
     {
         var project = await mediator.Send(new GetProject(projectIdentifier));
+
+        if (!catalogAccess.CanAccessProject(project.StartDate, project.EndDate))
+            return Forbid();
 
         return new ApiProject(project);
     }
@@ -67,6 +70,10 @@ public class ProjectsController(IMediator mediator) : ControllerBase
     public async Task<ActionResult<List<ApiSet>>> GetSetsForProject(string projectIdentifier)
     {
         var project = await mediator.Send(new GetProject(projectIdentifier));
+
+        if (!catalogAccess.CanAccessProject(project.StartDate, project.EndDate))
+            return Forbid();
+
         var sets = await mediator.Send(new GetSetsForProject(project.Id));
 
         return sets.Select(s => new ApiSet(s)).ToList();

--- a/src/SheetMusic.Api/Sets/SheetMusicController.cs
+++ b/src/SheetMusic.Api/Sets/SheetMusicController.cs
@@ -31,11 +31,13 @@ namespace SheetMusic.Api.Sets;
 [Route("sheetmusic")]
 [ApiVersion("1.0", Deprecated = true)]
 [ApiVersion("2.0")]
-public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCache, IMediator mediator) : ControllerBase
+public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCache, IMediator mediator, CatalogAccessService catalogAccess) : ControllerBase
 {
     private const long MaxFileSize = 300000000L; //300 MB
 
     private const string SupportedSetExpand = "parts";
+
+    private static readonly object DownloadTokenLock = new();
 
     /// <summary>
     /// Gets complete list of sheet music sets (without parts), or the ones matching <paramref name="queryParams.Search"/> if provided
@@ -74,8 +76,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         }
 
         var matchingSets = await mediator.Send(new GetSets(queryParams, categoryId));
+    var accessibleSetIds = await catalogAccess.GetAccessibleSetIdsAsync(matchingSets.Select(set => set.Id));
 
-        var transformed = matchingSets.Select(s => new ApiSet(s)
+    var transformed = matchingSets.Where(set => accessibleSetIds.Contains(set.Id)).Select(s => new ApiSet(s)
         {
             ZipDownloadUrl = $"{BaseUrl}/sets/{s.Id}/zip",
             PartsUrl = $"{BaseUrl}/sets/{s.Id}/parts",
@@ -108,6 +111,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{identifier}' was not found" });
+
+        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+            return Forbid();
 
         var query = new GetPartsForSet(set.Id);
         var parts = await mediator.Send(query);
@@ -143,6 +149,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         if (partOnSet == null)
             return NotFound(new ProblemDetails { Detail = $"Relationship between '{setIdentifier}' and '{partIdentifier}' was not found" });
 
+        if (!await catalogAccess.CanAccessSetAsync(partOnSet.SetId))
+            return Forbid();
+
         return new OkObjectResult(new ApiSheetMusicPart(partOnSet));
     }
 
@@ -156,7 +165,6 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <response code="200">The PDF file content</response>
     /// <response code="400">If the download token is missing or invalid</response>
     /// <response code="404">Set, part, or the relationship between them was not found</response>
-    [AllowAnonymous]
     [Produces("application/pdf")]
     [HttpGet("sets/{setIdentifier}/parts/{partIdentifier}/pdf")]
     public async Task<IActionResult> GetSinglePartFile(string setIdentifier, string partIdentifier, string downloadToken)
@@ -166,14 +174,15 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         if (partOnSet == null)
             return NotFound(new ProblemDetails { Detail = $"Relationship between '{setIdentifier}' and '{partIdentifier}' was not found" });
 
-        if (string.IsNullOrEmpty(downloadToken) || !TokenIsValid(partOnSet.SetId, downloadToken))
+        if (!await catalogAccess.CanAccessSetAsync(partOnSet.SetId))
+            return Forbid();
+
+        if (string.IsNullOrEmpty(downloadToken) || !TryConsumeDownloadToken(partOnSet.SetId, downloadToken))
         {
             return new BadRequestObjectResult("Download token must be provided and valid");
         }
 
         var pdf = await blobClient.GetMusicPartContentAsync(new PartRelatedToSet(partOnSet.SetId, partOnSet.MusicPartId));
-
-        memoryCache.Remove(DownloadTokenCacheKey(partOnSet.SetId)); //this is a one-time token
 
         return File(pdf, "application/pdf", $"{partOnSet.Part.Name}.pdf");
     }
@@ -194,6 +203,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{setIdentifier}' was not found" });
+
+        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+            return Forbid();
 
         return new OkObjectResult(new ApiSet(set)
         {
@@ -249,6 +261,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{setIdentifier}' was not found" });
+
+        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+            return Forbid();
 
         var categories = set.Categories.Where(c => c.Category != null).Select(c => new ApiCategory(c.Category)).ToList();
 
@@ -318,6 +333,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{setIdentifier}' was not found" });
 
+        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+            return Forbid();
+
         //generated token using cryptographic library, save to memory cache and verify on download
         var token = KeyGenerator.GetUniqueKey(64);
         memoryCache.Set(DownloadTokenCacheKey(set.Id), token, TimeSpan.FromMinutes(60));
@@ -335,7 +353,6 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <response code="200">The zipped collection of parts</response>
     /// <response code="400">If the download token is missing or invalid</response>
     /// <response code="404">Set not found</response>
-    [AllowAnonymous]
     [Produces("application/zip")]
     [HttpGet("sets/{setIdentifier}/zip")]
     public async Task<IActionResult> GetPartsForSetAzZip(string setIdentifier, string downloadToken)
@@ -345,7 +362,10 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{setIdentifier}' was not found" });
 
-        if (string.IsNullOrEmpty(downloadToken) || !TokenIsValid(set.Id, downloadToken))
+        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+            return Forbid();
+
+        if (string.IsNullOrEmpty(downloadToken) || !TryConsumeDownloadToken(set.Id, downloadToken))
         {
             return new BadRequestObjectResult("Download token must be provided and valid");
         }
@@ -353,8 +373,6 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         var zipStream = await mediator.Send(new GetPartsZipAsStream(setIdentifier));
         await zipStream.FlushAsync();
         zipStream.Position = 0;
-
-        memoryCache.Remove(DownloadTokenCacheKey(set.Id)); //this is a one-time token
 
         return File(zipStream, "application/zip", $"{set.Title}.zip");
     }
@@ -374,9 +392,10 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         queryParams.Expand.Add("parts");
 
         var setsWithParts = await mediator.Send(new GetSets(queryParams));
+        var accessibleSetIds = await catalogAccess.GetAccessibleSetIdsAsync(setsWithParts.Select(set => set.Id));
         var results = new List<ApiSet>();
 
-        foreach (var setWithParts in setsWithParts)
+        foreach (var setWithParts in setsWithParts.Where(set => accessibleSetIds.Contains(set.Id)))
         {
             var apiSet = new ApiSet(setWithParts);
 
@@ -550,16 +569,16 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
     private static string DownloadTokenCacheKey(Guid setId) => $"Download_{setId}";
 
-    private bool TokenIsValid(Guid setId, string providedToken)
+    private bool TryConsumeDownloadToken(Guid setId, string providedToken)
     {
-        if (memoryCache.TryGetValue(DownloadTokenCacheKey(setId), out string? cachedToken))
+        lock (DownloadTokenLock)
         {
-            if (providedToken == cachedToken)
+            if (memoryCache.TryGetValue(DownloadTokenCacheKey(setId), out string? cachedToken) && providedToken == cachedToken)
             {
+                memoryCache.Remove(DownloadTokenCacheKey(setId));
                 return true;
             }
         }
-
         return false;
     }
 }

--- a/src/SheetMusic.Api/Sets/SheetMusicController.cs
+++ b/src/SheetMusic.Api/Sets/SheetMusicController.cs
@@ -165,6 +165,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <response code="200">The PDF file content</response>
     /// <response code="400">If the download token is missing or invalid</response>
     /// <response code="404">Set, part, or the relationship between them was not found</response>
+    [AllowAnonymous]
     [Produces("application/pdf")]
     [HttpGet("sets/{setIdentifier}/parts/{partIdentifier}/pdf")]
     public async Task<IActionResult> GetSinglePartFile(string setIdentifier, string partIdentifier, string downloadToken)
@@ -173,9 +174,6 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
         if (partOnSet == null)
             return NotFound(new ProblemDetails { Detail = $"Relationship between '{setIdentifier}' and '{partIdentifier}' was not found" });
-
-        if (!await catalogAccess.CanAccessSetAsync(partOnSet.SetId))
-            return Forbid();
 
         if (string.IsNullOrEmpty(downloadToken) || !TryConsumeDownloadToken(partOnSet.SetId, downloadToken))
         {
@@ -338,7 +336,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
         //generated token using cryptographic library, save to memory cache and verify on download
         var token = KeyGenerator.GetUniqueKey(64);
-        memoryCache.Set(DownloadTokenCacheKey(set.Id), token, TimeSpan.FromMinutes(60));
+        memoryCache.Set(DownloadTokenCacheKey(token), set.Id, TimeSpan.FromMinutes(60));
 
         return new OkObjectResult(token);
     }
@@ -353,6 +351,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <response code="200">The zipped collection of parts</response>
     /// <response code="400">If the download token is missing or invalid</response>
     /// <response code="404">Set not found</response>
+    [AllowAnonymous]
     [Produces("application/zip")]
     [HttpGet("sets/{setIdentifier}/zip")]
     public async Task<IActionResult> GetPartsForSetAzZip(string setIdentifier, string downloadToken)
@@ -361,9 +360,6 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{setIdentifier}' was not found" });
-
-        if (!await catalogAccess.CanAccessSetAsync(set.Id))
-            return Forbid();
 
         if (string.IsNullOrEmpty(downloadToken) || !TryConsumeDownloadToken(set.Id, downloadToken))
         {
@@ -567,15 +563,15 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
     private string BaseUrl => $"{Request.Scheme}://{Request.Host}/sheetmusic";
 
-    private static string DownloadTokenCacheKey(Guid setId) => $"Download_{setId}";
+    private static string DownloadTokenCacheKey(string token) => $"Download_{token}";
 
     private bool TryConsumeDownloadToken(Guid setId, string providedToken)
     {
         lock (DownloadTokenLock)
         {
-            if (memoryCache.TryGetValue(DownloadTokenCacheKey(setId), out string? cachedToken) && providedToken == cachedToken)
+            if (memoryCache.TryGetValue(DownloadTokenCacheKey(providedToken), out Guid tokenSetId) && tokenSetId == setId)
             {
-                memoryCache.Remove(DownloadTokenCacheKey(setId));
+                memoryCache.Remove(DownloadTokenCacheKey(providedToken));
                 return true;
             }
         }

--- a/src/SheetMusic.Api/Users/Authorization/CatalogAccessService.cs
+++ b/src/SheetMusic.Api/Users/Authorization/CatalogAccessService.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using SheetMusic.Api.Database;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Authorization;
+
+/// <summary>
+/// Resolves the catalogue resources available to the current user.
+/// </summary>
+public class CatalogAccessService(SheetMusicContext db, IHttpContextAccessor httpContextAccessor)
+{
+    /// <summary>Gets whether the current user can access the specified set.</summary>
+    public async Task<bool> CanAccessSetAsync(Guid setId, CancellationToken cancellationToken = default)
+    {
+        if (HasFullLibraryAccess())
+            return true;
+
+        if (!IsMusikant())
+            return false;
+
+        var now = DateTime.UtcNow;
+        return await db.ProjectSheetMusicSets.AnyAsync(connection =>
+            connection.SheetMusicSetId == setId &&
+            connection.Project.StartDate <= now &&
+            connection.Project.EndDate >= now,
+            cancellationToken);
+    }
+
+    /// <summary>Gets whether the current user can access the specified project.</summary>
+    public bool CanAccessProject(DateTime startDate, DateTime endDate) =>
+        HasFullLibraryAccess() || (IsMusikant() && startDate <= DateTime.UtcNow && endDate >= DateTime.UtcNow);
+
+    /// <summary>Filters set identifiers to the catalogue resources visible to the current user.</summary>
+    public async Task<HashSet<Guid>> GetAccessibleSetIdsAsync(IEnumerable<Guid> setIds, CancellationToken cancellationToken = default)
+    {
+        var ids = setIds.ToList();
+        if (HasFullLibraryAccess())
+            return [.. ids];
+
+        if (!IsMusikant())
+            return [];
+
+        var now = DateTime.UtcNow;
+        return [.. await db.ProjectSheetMusicSets
+            .Where(connection => ids.Contains(connection.SheetMusicSetId) &&
+                connection.Project.StartDate <= now && connection.Project.EndDate >= now)
+            .Select(connection => connection.SheetMusicSetId)
+            .ToListAsync(cancellationToken)];
+    }
+
+    private bool HasFullLibraryAccess() => User.IsInRole(Roles.Admin) || User.IsInRole(Roles.Noteansvarlig) || User.IsInRole(Roles.Arkivleser);
+
+    private bool IsMusikant() => User.IsInRole(Roles.Musikant);
+
+    private ClaimsPrincipal User => httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal();
+}

--- a/src/SheetMusic.Api/Users/Authorization/Roles.cs
+++ b/src/SheetMusic.Api/Users/Authorization/Roles.cs
@@ -26,6 +26,11 @@ public static class Roles
     public const string Musikant = "Musikant";
 
     /// <summary>
+    /// Library reader. Read-only access to the entire music catalogue, including sets outside active projects.
+    /// </summary>
+    public const string Arkivleser = "Arkivleser";
+
+    /// <summary>
     /// Project manager. Can create, update and delete Projects and manage which sets are assigned to them,
     /// but has no edit rights over Sets, Parts or Categories.
     /// </summary>
@@ -34,5 +39,5 @@ public static class Roles
     /// <summary>
     /// All role names that can be assigned to a user.
     /// </summary>
-    public static readonly string[] All = [Admin, Noteansvarlig, Musikant, Prosjektleder];
+    public static readonly string[] All = [Admin, Noteansvarlig, Musikant, Arkivleser, Prosjektleder];
 }

--- a/src/SheetMusic.Api/Users/RequestModels/AssignRoleRequest.cs
+++ b/src/SheetMusic.Api/Users/RequestModels/AssignRoleRequest.cs
@@ -6,7 +6,7 @@ namespace SheetMusic.Api.Users.RequestModels;
 public class AssignRoleRequest
 {
     /// <summary>
-    /// The name of the role to assign. Must be one of <c>Admin</c>, <c>Noteansvarlig</c>, <c>Musikant</c> or <c>Prosjektleder</c>.
+    /// The name of the role to assign. Must be one of <c>Admin</c>, <c>Noteansvarlig</c>, <c>Musikant</c>, <c>Arkivleser</c> or <c>Prosjektleder</c>.
     /// </summary>
     public string RoleName { get; set; } = null!;
 


### PR DESCRIPTION
## Summary
- add Arkivleser and active-project scoped catalog access for Musikant
- enforce scope for project/set reads and download-token issuance
- allow anonymous one-time ZIP/PDF downloads that trust a valid, set-bound issued token
- add role, token-binding, replay, and concurrent-consumption integration coverage

## Validation
- dotnet test src/SheetMusic.Api.Test/SheetMusic.Api.Test.csproj --filter "FullyQualifiedName~GetSinglePartFile_ShouldBeSuccessfull|FullyQualifiedName~GetPartsAsZip_ShouldAllowEachIssuedTokenToBeUsedOnce|FullyQualifiedName~GetCatalogResources_ShouldRespectActiveProjectScope" --no-restore

Closes #314