### PR TITLE
feat(parts): add instrument group classification

### DIFF
--- a/src/SheetMusic.Api.Test/Parts/PartTests.cs
+++ b/src/SheetMusic.Api.Test/Parts/PartTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Parts;
 using SheetMusic.Api.Parts.ViewModels;
 using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
@@ -15,6 +16,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -109,6 +111,117 @@ public class PartTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
 
         var response = await adminClient.PutAsJsonAsync($"parts/{part.Id}", input);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Part_ShouldRoundTripInstrumentGroup_WhenCreatedAndUpdated()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var createResponse = await adminClient.PostAsJsonAsync("parts", new
+        {
+            Name = $"instrument-group-{Guid.NewGuid():N}",
+            SortOrder = 1,
+            Indexable = true,
+            InstrumentGroup = "Horn og flygelhorn"
+        });
+        createResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var responseBody = await createResponse.Content.ReadAsStringAsync();
+        responseBody.Should().Contain("\"instrumentGroup\":\"Horn og flygelhorn\"");
+        var created = JsonSerializer.Deserialize<ApiPart>(responseBody, JsonDefaults.Options);
+        created.Should().NotBeNull();
+        created!.InstrumentGroup.Should().Be(InstrumentGroup.HornOgFlygelhorn);
+
+        var updateResponse = await adminClient.PutAsJsonAsync($"parts/{created.Id}", new
+        {
+            created.Name,
+            created.SortOrder,
+            created.Indexable,
+            InstrumentGroup = "Euphonium og baryton"
+        });
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updateResponseBody = await updateResponse.Content.ReadAsStringAsync();
+        updateResponseBody.Should().Contain("\"instrumentGroup\":\"Euphonium og baryton\"");
+
+        var getResponse = await adminClient.GetAsync($"parts/{created.Id}");
+        var updated = await getResponse.Content.ReadFromJsonAsync<ApiPart>(JsonDefaults.Options);
+        updated!.InstrumentGroup.Should().Be(InstrumentGroup.EuphoniumOgBaryton);
+    }
+
+    [Fact]
+    public async Task Part_ShouldReturnNullInstrumentGroup_WhenNoGroupIsProvided()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var response = await adminClient.PostAsJsonAsync("parts", new
+        {
+            Name = $"unclassified-part-{Guid.NewGuid():N}",
+            SortOrder = 1,
+            Indexable = true
+        });
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var part = await response.Content.ReadFromJsonAsync<ApiPart>(JsonDefaults.Options);
+        part.Should().NotBeNull();
+        part!.InstrumentGroup.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdatePart_ShouldClearInstrumentGroup_WhenNoGroupIsProvided()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var createResponse = await adminClient.PostAsJsonAsync("parts", new
+        {
+            Name = $"clear-instrument-group-{Guid.NewGuid():N}",
+            SortOrder = 1,
+            Indexable = true,
+            InstrumentGroup = "Tuba"
+        });
+        var created = await createResponse.Content.ReadFromJsonAsync<ApiPart>(JsonDefaults.Options);
+
+        var updateResponse = await adminClient.PutAsJsonAsync($"parts/{created!.Id}", new
+        {
+            created.Name,
+            created.SortOrder,
+            created.Indexable,
+            InstrumentGroup = (string?)null
+        });
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var updated = await updateResponse.Content.ReadFromJsonAsync<ApiPart>(JsonDefaults.Options);
+        updated!.InstrumentGroup.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreatePart_ShouldReturnBadRequest_WhenInstrumentGroupIsUnsupported()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+
+        var response = await adminClient.PostAsJsonAsync("parts", new
+        {
+            Name = $"invalid-instrument-group-{Guid.NewGuid():N}",
+            SortOrder = 1,
+            Indexable = true,
+            InstrumentGroup = "Ukjent"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdatePart_ShouldReturnBadRequest_WhenInstrumentGroupIsUnsupported()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var part = await new PartDataBuilder(adminClient).ProvisionSinglePartAsync();
+
+        var response = await adminClient.PutAsJsonAsync($"parts/{part.Id}", new
+        {
+            part.Name,
+            part.SortOrder,
+            part.Indexable,
+            InstrumentGroup = "Ukjent"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]

--- a/src/SheetMusic.Api.Test/Utility/FakerFactory.cs
+++ b/src/SheetMusic.Api.Test/Utility/FakerFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Bogus;
+using SheetMusic.Api.Parts;
 using SheetMusic.Api.Parts.RequestModels;
 using SheetMusic.Api.Test.Sets.Models;
 using System;
@@ -27,7 +28,8 @@ internal static class FakerFactory
         var faker = new Faker<PartRequest>(Norwegian)
             .RuleFor(p => p.Name, f => $"{f.Lorem.Word()}-{f.UniqueIndex}")
             .RuleFor(p => p.SortOrder, f => f.Random.Int(1, 99))
-            .RuleFor(p => p.Indexable, f => f.Random.Bool());
+            .RuleFor(p => p.Indexable, f => f.Random.Bool())
+            .RuleFor(p => p.InstrumentGroup, f => f.PickRandom<InstrumentGroup>());
 
         return faker;
     }

--- a/src/SheetMusic.Api.Test/Utility/PartDataBuilder.cs
+++ b/src/SheetMusic.Api.Test/Utility/PartDataBuilder.cs
@@ -55,5 +55,6 @@ public class PartDataBuilder(HttpClient httpClient)
         apiPart?.Name.Should().Be(item.Name);
         apiPart?.SortOrder.Should().Be(item.SortOrder);
         apiPart?.Indexable.Should().Be(item.Indexable ?? false);
+        apiPart?.InstrumentGroup.Should().Be(item.InstrumentGroup);
     }
 }

--- a/src/SheetMusic.Api/Database/Entities/MusicPart.cs
+++ b/src/SheetMusic.Api/Database/Entities/MusicPart.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using SheetMusic.Api.Parts;
 
 namespace SheetMusic.Api.Database.Entities;
 
@@ -9,6 +11,8 @@ public class MusicPart
     public string Name { get; set; } = null!;
     public int SortOrder { get; set; }
     public bool Indexable { get; set; }
+    [Column(TypeName = "varchar(50)")]
+    public InstrumentGroup? InstrumentGroup { get; set; }
 
     public List<SheetMusicPart> Parts { get; set; } = null!;
     public List<MusicianMusicPart> MusicianMusicParts { get; set; } = null!;

--- a/src/SheetMusic.Api/Database/SheetMusicContext.cs
+++ b/src/SheetMusic.Api/Database/SheetMusicContext.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Parts;
 
 namespace SheetMusic.Api.Database;
 

--- a/src/SheetMusic.Api/Migrations/20260805080102_AddInstrumentGroupToMusicPart.Designer.cs
+++ b/src/SheetMusic.Api/Migrations/20260805080102_AddInstrumentGroupToMusicPart.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SheetMusic.Api.Database;
 
@@ -11,9 +12,11 @@ using SheetMusic.Api.Database;
 namespace SheetMusic.Api.Migrations
 {
     [DbContext(typeof(SheetMusicContext))]
-    partial class SheetMusicContextModelSnapshot : ModelSnapshot
+    [Migration("20260805080102_AddInstrumentGroupToMusicPart")]
+    partial class AddInstrumentGroupToMusicPart
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SheetMusic.Api/Migrations/20260805080102_AddInstrumentGroupToMusicPart.cs
+++ b/src/SheetMusic.Api/Migrations/20260805080102_AddInstrumentGroupToMusicPart.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SheetMusic.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstrumentGroupToMusicPart : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InstrumentGroup",
+                table: "MusicParts",
+                type: "varchar(50)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InstrumentGroup",
+                table: "MusicParts");
+        }
+    }
+}

--- a/src/SheetMusic.Api/Parts/Commands/AddPart.cs
+++ b/src/SheetMusic.Api/Parts/Commands/AddPart.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Parts.Errors;
@@ -9,17 +10,18 @@ using System.Threading.Tasks;
 
 namespace SheetMusic.Api.Parts.Commands;
 
-public class AddPart(string name, int sortOrder, bool indexable) : IRequest<MusicPart>
+public class AddPart(string name, int sortOrder, bool indexable, InstrumentGroup? instrumentGroup) : IRequest<MusicPart>
 {
     public string Name { get; } = name;
     public int SortOrder { get; } = sortOrder;
     public bool Indexable { get; } = indexable;
+    public InstrumentGroup? InstrumentGroup { get; } = instrumentGroup;
 
     public class Handler(SheetMusicContext db) : IRequestHandler<AddPart, MusicPart>
     {
         public async Task<MusicPart> Handle(AddPart request, CancellationToken cancellationToken)
         {
-            if (db.MusicParts.Any(p => p.Name.ToLower() == request.Name.ToLower()))
+            if (await db.MusicParts.AnyAsync(p => p.Name.ToLower() == request.Name.ToLower(), cancellationToken))
                 throw new PartAlreadyExistsError(request.Name);
 
             var part = new MusicPart
@@ -27,7 +29,8 @@ public class AddPart(string name, int sortOrder, bool indexable) : IRequest<Musi
                 Id = Guid.NewGuid(),
                 Name = request.Name,
                 Indexable = request.Indexable,
-                SortOrder = request.SortOrder
+                SortOrder = request.SortOrder,
+                InstrumentGroup = request.InstrumentGroup
             };
 
             db.MusicParts.Add(part);

--- a/src/SheetMusic.Api/Parts/Commands/UpdatePart.cs
+++ b/src/SheetMusic.Api/Parts/Commands/UpdatePart.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace SheetMusic.Api.Parts.Commands;
 
-public class UpdatePart(Guid partId, string name, int sortOrder, bool indexable) : IRequest
+public class UpdatePart(Guid partId, string name, int sortOrder, bool indexable, InstrumentGroup? instrumentGroup) : IRequest
 {
     public Guid PartId { get; } = partId;
 
@@ -16,12 +16,13 @@ public class UpdatePart(Guid partId, string name, int sortOrder, bool indexable)
     public int SortOrder { get; } = sortOrder;
 
     public bool Indexable { get; } = indexable;
+    public InstrumentGroup? InstrumentGroup { get; } = instrumentGroup;
 
     public class Handler(SheetMusicContext db, IMediator mediator) : IRequestHandler<UpdatePart>
     {
         public async Task Handle(UpdatePart request, CancellationToken cancellationToken)
         {
-            var existingPart = await db.MusicParts.FirstOrDefaultAsync(p => p.Id == request.PartId);
+            var existingPart = await db.MusicParts.FirstOrDefaultAsync(p => p.Id == request.PartId, cancellationToken);
 
             if (existingPart == null)
                 throw new NotFoundError(request.PartId.ToString(), "Part not found");
@@ -30,11 +31,12 @@ public class UpdatePart(Guid partId, string name, int sortOrder, bool indexable)
             existingPart.Name = request.Name;
             existingPart.SortOrder = request.SortOrder;
             existingPart.Indexable = request.Indexable;
+            existingPart.InstrumentGroup = request.InstrumentGroup;
 
             if (db.ChangeTracker.HasChanges())
             {
-                await db.SaveChangesAsync();
-                await mediator.Send(new BuildPartIndex());
+                await db.SaveChangesAsync(cancellationToken);
+                await mediator.Send(new BuildPartIndex(), cancellationToken);
             }
         }
     }

--- a/src/SheetMusic.Api/Parts/InstrumentGroup.cs
+++ b/src/SheetMusic.Api/Parts/InstrumentGroup.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace SheetMusic.Api.Parts;
+
+[JsonConverter(typeof(JsonStringEnumConverter<InstrumentGroup>))]
+public enum InstrumentGroup
+{
+    Kornett,
+    [JsonStringEnumMemberName("Horn og flygelhorn")]
+    HornOgFlygelhorn,
+    [JsonStringEnumMemberName("Euphonium og baryton")]
+    EuphoniumOgBaryton,
+    Tromboner,
+    Tuba,
+    Slagverk
+}

--- a/src/SheetMusic.Api/Parts/PartsController.cs
+++ b/src/SheetMusic.Api/Parts/PartsController.cs
@@ -104,7 +104,7 @@ public class PartsController(IMediator mediator) : ControllerBase
     [HttpPost("parts")]
     public async Task<ActionResult<ApiPart>> AddNewPart(PartRequest request)
     {
-        var command = new AddPart(request.Name, request.SortOrder, request.Indexable ?? true);
+        var command = new AddPart(request.Name, request.SortOrder, request.Indexable ?? true, request.InstrumentGroup);
         var part = await mediator.Send(command);
 
         if (part is null)
@@ -151,7 +151,7 @@ public class PartsController(IMediator mediator) : ControllerBase
         if (part is null)
             return NotFound(new ProblemDetails { Detail = $"Part '{partIdentifier}' not found" });
 
-        var command = new UpdatePart(part.Id, request.Name, request.SortOrder, request.Indexable.GetValueOrDefault(false));
+        var command = new UpdatePart(part.Id, request.Name, request.SortOrder, request.Indexable.GetValueOrDefault(false), request.InstrumentGroup);
         await mediator.Send(command);
 
         part = await mediator.Send(new GetMusicPart(partIdentifier));

--- a/src/SheetMusic.Api/Parts/Queries/GetPartCollection.cs
+++ b/src/SheetMusic.Api/Parts/Queries/GetPartCollection.cs
@@ -25,6 +25,7 @@ public class GetPartCollection(ODataQueryParams queryParams) : IRequest<List<Mus
             m.MapField("name", p => p.Name);
             m.MapField("indexable", p => p.Indexable);
             m.MapField("sortOrder", p => p.SortOrder);
+            m.MapField("instrumentGroup", p => p.InstrumentGroup);
         };
 
         public async Task<List<MusicPart>> Handle(GetPartCollection request, CancellationToken cancellationToken)

--- a/src/SheetMusic.Api/Parts/RequestModels/PartRequest.cs
+++ b/src/SheetMusic.Api/Parts/RequestModels/PartRequest.cs
@@ -10,6 +10,8 @@ public class PartRequest
 
     public bool? Indexable { get; set; }
 
+    public InstrumentGroup? InstrumentGroup { get; set; }
+
     public class Validator : AbstractValidator<PartRequest>
     {
         public Validator()
@@ -20,6 +22,9 @@ public class PartRequest
                 .LessThanOrEqualTo(99)
                 .WithMessage("SortOrder must be a value between 1 and 99. 1 appears before 99 and so on");
             RuleFor(p => p.Indexable).NotNull().WithMessage("Indexable flag is required");
+            RuleFor(p => p.InstrumentGroup)
+                .Must(group => group is null || Enum.IsDefined(group.Value))
+                .WithMessage("InstrumentGroup must be one of the supported instrument groups");
         }
     }
 }

--- a/src/SheetMusic.Api/Parts/ViewModels/ApiPart.cs
+++ b/src/SheetMusic.Api/Parts/ViewModels/ApiPart.cs
@@ -1,4 +1,5 @@
 ﻿using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Parts;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,6 +21,7 @@ public class ApiPart
         Name = part.Name;
         SortOrder = part.SortOrder;
         Indexable = part.Indexable;
+        InstrumentGroup = part.InstrumentGroup;
         Aliases = part.Aliases?.Where(a => a.Enabled).Select(a => a.Alias).ToList() ?? new List<string>();
     }
 
@@ -30,6 +32,8 @@ public class ApiPart
     public int SortOrder { get; set; }
 
     public bool Indexable { get; set; }
+
+    public InstrumentGroup? InstrumentGroup { get; set; }
 
     public List<string> Aliases { get; set; } = new List<string>();
 }


### PR DESCRIPTION
## Summary
- add a fixed Norwegian instrument-group classification to every music part
- expose and validate the classification through the parts API, including OData filtering
- add an EF Core migration that backfills existing parts with Kornett

## Testing
- dotnet test src/SheetMusic.Api.Test/SheetMusic.Api.Test.csproj --filter FullyQualifiedName~SheetMusic.Api.Test.Parts.PartTests --no-restore
- 52 passed