### PR TITLE
fix(users): persist profile updates

### DIFF
--- a/src/SheetMusic.Api.Test/Users/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Users/UserTests.cs
@@ -382,6 +382,71 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
+    public async Task V2_UpdateUser_ShouldPersistNameAndEmail_WhenProfileFieldsAreProvided()
+    {
+        var anonymousClient = CreateV2Client();
+        var originalEmail = $"update-{Guid.NewGuid():N}@user.com";
+        var updatedEmail = $"updated-{Guid.NewGuid():N}@user.com";
+        var userId = Guid.NewGuid();
+
+        var registerResponse = await anonymousClient.PostAsJsonAsync("users/register", new
+        {
+            Id = userId,
+            Name = "Original User",
+            Email = originalEmail,
+            Password = "Original123!"
+        });
+        registerResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var adminClient = CreateV2ClientWithTestToken(TestUser.Administrator);
+        var updateResponse = await adminClient.PutAsJsonAsync($"users/{userId}", new
+        {
+            Name = "Updated User",
+            Email = updatedEmail
+        });
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var getResponse = await adminClient.GetAsync($"users/{userId}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var updatedUser = await getResponse.Content.ReadFromJsonAsync<UserResponse>(JsonDefaults.Options);
+        updatedUser.Should().NotBeNull();
+        updatedUser!.Name.Should().Be("Updated User");
+        updatedUser.Email.Should().Be(updatedEmail);
+
+        using var scope = factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var identityUser = await userManager.FindByIdAsync(userId.ToString());
+        identityUser!.UserName.Should().Be(updatedEmail);
+    }
+
+    [Fact]
+    public async Task V2_UpdateUser_ShouldReturnBadRequest_WhenEmailIsAlreadyInUse()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+
+        var response = await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}", new
+        {
+            Email = TestUser.Administrator.Email
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_UpdateUser_ShouldReturnBadRequest_WhenEmailIsInvalid()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+
+        var response = await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}", new
+        {
+            Email = "not-an-email"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task V2_UpdateUser_ShouldBeForbidden_WhenNonAdmin()
     {
         var client = CreateV2ClientWithTestToken(TestUser.Testesen);
@@ -1166,5 +1231,11 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
 
         responses.Count(r => r.StatusCode == HttpStatusCode.OK).Should().Be(1);
         responses.Count(r => r.StatusCode == HttpStatusCode.BadRequest).Should().Be(1);
+    }
+
+    private sealed class UserResponse
+    {
+        public string Name { get; set; } = null!;
+        public string Email { get; set; } = null!;
     }
 }

--- a/src/SheetMusic.Api/Users/Commands/UpdateUser.cs
+++ b/src/SheetMusic.Api/Users/Commands/UpdateUser.cs
@@ -1,0 +1,72 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Errors;
+using SheetMusic.Api.Users.Authorization;
+using SheetMusic.Api.Users.Errors;
+using SheetMusic.Api.Users.RequestModels;
+using SheetMusic.Api.Users.ViewModels;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Commands;
+
+public class UpdateUser(Guid userId, ClaimsPrincipal authenticatedUser, UpdateUserRequest user) : IRequest
+{
+    public Guid UserId { get; } = userId;
+    public ClaimsPrincipal AuthenticatedUser { get; } = authenticatedUser;
+    public UpdateUserRequest User { get; } = user;
+
+    public class Handler(UserManager<ApplicationUser> userManager, IOptions<IdentityOptions> identityOptions) : IRequestHandler<UpdateUser>
+    {
+        public async Task Handle(UpdateUser request, CancellationToken cancellationToken)
+        {
+            if (!Guid.TryParse(request.AuthenticatedUser.FindFirst(ClaimTypes.Name)?.Value, out var authenticatedUserId))
+                throw new UnableToIdentifyUserError();
+
+            var currentUser = await userManager.FindByIdAsync(authenticatedUserId.ToString());
+            var isAdmin = currentUser != null && await userManager.IsInRoleAsync(currentUser, Roles.Admin);
+            var userToChange = await userManager.FindByIdAsync(request.UserId.ToString())
+                ?? throw new NotFoundError($"users/{request.UserId}", "User not found");
+
+            if (authenticatedUserId != request.UserId && !isAdmin)
+                throw new UserUpdateForbiddenError();
+
+            var profileWasUpdated = false;
+
+            if (!string.IsNullOrWhiteSpace(request.User.Name))
+            {
+                userToChange.DisplayName = request.User.Name;
+                profileWasUpdated = true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.User.Email))
+            {
+                userToChange.Email = request.User.Email;
+                userToChange.UserName = request.User.Email;
+                profileWasUpdated = true;
+            }
+
+            if (profileWasUpdated)
+            {
+                var result = await userManager.UpdateAsync(userToChange);
+
+                if (!result.Succeeded)
+                    throw new IdentityOperationError(result.Errors.Select(e => e.Description));
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.User.Password))
+            {
+                var token = await userManager.GeneratePasswordResetTokenAsync(userToChange);
+                var result = await userManager.ResetPasswordAsync(userToChange, token, request.User.Password);
+
+                if (!result.Succeeded)
+                    throw PasswordRequirementsNotMetError.FromFailedResult(result, ApiPasswordRequirements.FromPasswordOptions(identityOptions.Value.Password));
+            }
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/Errors/UnableToIdentifyUserError.cs
+++ b/src/SheetMusic.Api/Users/Errors/UnableToIdentifyUserError.cs
@@ -1,0 +1,9 @@
+using SheetMusic.Api.Errors;
+using System.Net;
+
+namespace SheetMusic.Api.Users.Errors;
+
+public class UnableToIdentifyUserError() : ExceptionBase("Unable to find Name claim and identify user")
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+}

--- a/src/SheetMusic.Api/Users/Errors/UserUpdateForbiddenError.cs
+++ b/src/SheetMusic.Api/Users/Errors/UserUpdateForbiddenError.cs
@@ -1,0 +1,9 @@
+using SheetMusic.Api.Errors;
+using System.Net;
+
+namespace SheetMusic.Api.Users.Errors;
+
+public class UserUpdateForbiddenError() : ExceptionBase("Only the user themselves or an Administrator can update the user")
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.Forbidden;
+}

--- a/src/SheetMusic.Api/Users/UsersController.cs
+++ b/src/SheetMusic.Api/Users/UsersController.cs
@@ -85,42 +85,21 @@ public class UsersController(UserManager<ApplicationUser> userManager, IMediator
     }
 
     /// <summary>
-    /// Update a user's password. Admins can update any user.
+    /// Update a user's name, email address, or password. Admins can update any user.
     /// </summary>
     /// <param name="identifier">The guid of the user to update</param>
-    /// <param name="request">The new password</param>
-    /// <response code="200">Password was updated successfully</response>
-    /// <response code="400">Unable to identify the authenticated user, or the new password does not
-    /// meet the requirements returned by <c>GET users/password-requirements</c> (<see cref="PasswordRequirementsNotMetError"/>).
-    /// The existing password remains valid in that case.</response>
+    /// <param name="request">The updated user details</param>
+    /// <response code="200">User was updated successfully</response>
+    /// <response code="400">Unable to identify the authenticated user, the new email is invalid or already in use,
+    /// or the new password does not meet the requirements returned by <c>GET users/password-requirements</c>
+    /// (<see cref="PasswordRequirementsNotMetError"/>).</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
     /// <response code="403">Forbidden. Only the user themselves or an Administrator can update the password</response>
     /// <response code="404">User not found</response>
     [HttpPut("users/{identifier}")]
     public async Task<IActionResult> UpdateUser(Guid identifier, [FromBody] UpdateUserRequest request)
     {
-        if (!Guid.TryParse(User.FindFirstValue(ClaimTypes.Name), out Guid authenticatedUserId))
-            return BadRequest("Unable to find Name claim and identify user");
-
-        var currentUser = await userManager.FindByIdAsync(authenticatedUserId.ToString());
-        var isAdmin = currentUser != null && await userManager.IsInRoleAsync(currentUser, Roles.Admin);
-        var userToChange = await userManager.FindByIdAsync(identifier.ToString());
-
-        if (userToChange == null)
-            return NotFound();
-
-        if (authenticatedUserId != identifier && !isAdmin)
-            return Forbid();
-
-        if (!string.IsNullOrWhiteSpace(request.Password))
-        {
-            var token = await userManager.GeneratePasswordResetTokenAsync(userToChange);
-            var result = await userManager.ResetPasswordAsync(userToChange, token, request.Password);
-
-            if (!result.Succeeded)
-                throw PasswordRequirementsNotMetError.FromFailedResult(result, ApiPasswordRequirements.FromPasswordOptions(identityOptions.Value.Password));
-        }
-
+        await mediator.Send(new UpdateUser(identifier, User, request));
         return Ok();
     }
 


### PR DESCRIPTION
## Summary
- persist supplied user name and email during user updates
- update the Identity username alongside the email and return validation errors for invalid or duplicate addresses
- move the update workflow into a MediatR command

## Testing
- dotnet test src/SheetMusic.Api.Test/SheetMusic.Api.Test.csproj --no-restore --filter FullyQualifiedName~V2_UpdateUser