### PR TITLE
feat(users): assign parts to musicians

### DIFF
--- a/src/SheetMusic.Api.Test/Users/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Users/UserTests.cs
@@ -370,6 +370,141 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
+    public async Task V2_AssignParts_ShouldBeForbidden_WhenNonAdmin()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Musikant);
+
+        var response = await client.PutAsJsonAsync($"users/{TestUser.Testesen.Identifier}/parts", new { PartIds = Array.Empty<Guid>() });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task V2_AssignParts_ShouldReturnUnauthorized_WhenUnauthenticated()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}/parts", new { PartIds = Array.Empty<Guid>() });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task V2_AssignParts_ShouldReturnBadRequest_WhenPartIdsAreNull()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+
+        var response = await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}/parts", new { PartIds = (Guid[]?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_AssignParts_ShouldReturnNotFound_WhenPartDoesNotExist()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+
+        var response = await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}/parts", new { PartIds = new[] { Guid.NewGuid() } });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task V2_AssignParts_ShouldReturnAssignedParts_WhenRetrievingUser()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+        var parts = new[]
+        {
+            new MusicPart { Id = Guid.NewGuid(), Name = "Part one", SortOrder = 2, Indexable = true },
+            new MusicPart { Id = Guid.NewGuid(), Name = "Part two", SortOrder = 1, Indexable = true }
+        };
+
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            await db.MusicParts.AddRangeAsync(parts);
+            await db.SaveChangesAsync();
+        }
+
+        var assignResponse = await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}/parts", new { PartIds = parts.Select(part => part.Id) });
+        assignResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var user = await client.GetFromJsonAsync<ApiUserDetailModel>($"users/{TestUser.Musikant.Identifier}");
+        user!.Parts.Select(part => part.Id).Should().Equal(parts.OrderBy(part => part.SortOrder).Select(part => part.Id));
+    }
+
+    [Fact]
+    public async Task V2_AssignParts_ShouldReplaceExistingAssignments_WhenCalledAgain()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+        var parts = new[]
+        {
+            new MusicPart { Id = Guid.NewGuid(), Name = "Original part", Indexable = true },
+            new MusicPart { Id = Guid.NewGuid(), Name = "Replacement part", Indexable = true }
+        };
+
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            await db.MusicParts.AddRangeAsync(parts);
+            await db.SaveChangesAsync();
+        }
+
+        (await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}/parts", new { PartIds = new[] { parts[0].Id } })).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}/parts", new { PartIds = new[] { parts[1].Id } })).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var user = await client.GetFromJsonAsync<ApiUserDetailModel>($"users/{TestUser.Musikant.Identifier}");
+        user!.Parts.Select(part => part.Id).Should().Equal(parts[1].Id);
+    }
+
+    [Fact]
+    public async Task V2_AssignParts_ShouldClearExistingAssignments_WhenPartIdsAreEmpty()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+        var part = new MusicPart { Id = Guid.NewGuid(), Name = "Part to clear", Indexable = true };
+
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            await db.MusicParts.AddAsync(part);
+            await db.SaveChangesAsync();
+        }
+
+        (await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}/parts", new { PartIds = new[] { part.Id } })).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await client.PutAsJsonAsync($"users/{TestUser.Musikant.Identifier}/parts", new { PartIds = Array.Empty<Guid>() })).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var user = await client.GetFromJsonAsync<ApiUserDetailModel>($"users/{TestUser.Musikant.Identifier}");
+        user!.Parts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task V2_AssignParts_ShouldNotReplaceExistingAssignments_WhenPartIdsAreDuplicated()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+        var (userId, _) = await RegisterInactiveUserAsync(CreateV2Client(), "duplicate-part-ids");
+        var parts = new[]
+        {
+            new MusicPart { Id = Guid.NewGuid(), Name = "Existing part", Indexable = true },
+            new MusicPart { Id = Guid.NewGuid(), Name = "Duplicate part", Indexable = true }
+        };
+
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            await db.MusicParts.AddRangeAsync(parts);
+            await db.SaveChangesAsync();
+        }
+
+        (await client.PutAsJsonAsync($"users/{userId}/parts", new { PartIds = new[] { parts[0].Id } })).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var response = await client.PutAsJsonAsync($"users/{userId}/parts", new { PartIds = new[] { parts[1].Id, parts[1].Id } });
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var user = await client.GetFromJsonAsync<ApiUserDetailModel>($"users/{userId}");
+        user!.Parts.Select(part => part.Id).Should().Equal(parts[0].Id);
+    }
+
+    [Fact]
     public async Task V2_UpdateUser_ShouldBeSuccessful_WhenAdminUpdatesAnother()
     {
         var client = CreateV2ClientWithTestToken(TestUser.Administrator);
@@ -493,6 +628,10 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
         var loginResponse = await anonymousClient.PostAsync("token", BuildLoginForm(email, originalPassword));
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
+
+    private record ApiUserDetailModel(IReadOnlyList<ApiPartModel> Parts);
+
+    private record ApiPartModel(Guid Id);
 
     // --- User management: activate / deactivate / roles / delete ---
 

--- a/src/SheetMusic.Api/Users/Commands/AssignPartsToUser.cs
+++ b/src/SheetMusic.Api/Users/Commands/AssignPartsToUser.cs
@@ -1,0 +1,67 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using SheetMusic.Api.Database;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Errors;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Commands;
+
+public class AssignPartsToUser(Guid userId, IReadOnlyList<Guid> partIds) : IRequest
+{
+    public Guid UserId { get; } = userId;
+    public IReadOnlyList<Guid> PartIds { get; } = partIds;
+
+    public class Handler(SheetMusicContext db, UserManager<ApplicationUser> userManager) : IRequestHandler<AssignPartsToUser>
+    {
+        public async Task Handle(AssignPartsToUser request, CancellationToken cancellationToken)
+        {
+            var user = await userManager.FindByIdAsync(request.UserId.ToString())
+                ?? throw new NotFoundError($"users/{request.UserId}", "User not found");
+
+            var musician = await db.Musicians
+                .SingleOrDefaultAsync(m => m.ApplicationUserId == request.UserId, cancellationToken);
+
+            if (musician is null)
+            {
+                musician = new Musician
+                {
+                    Id = Guid.NewGuid(),
+                    Name = user.DisplayName,
+                    ApplicationUserId = user.Id
+                };
+                await db.Musicians.AddAsync(musician, cancellationToken);
+            }
+
+            var existingPartIds = await db.MusicParts
+                .Where(part => request.PartIds.Contains(part.Id))
+                .Select(part => part.Id)
+                .ToListAsync(cancellationToken);
+
+            if (existingPartIds.Count != request.PartIds.Count)
+                throw new NotFoundError("parts", "One or more parts were not found");
+
+            var existingAssignments = await db.Set<MusicianMusicPart>()
+                .Where(assignment => assignment.MusicianId == musician.Id)
+                .ToListAsync(cancellationToken);
+            db.RemoveRange(existingAssignments);
+
+            foreach (var partId in request.PartIds)
+            {
+                await db.Set<MusicianMusicPart>().AddAsync(new MusicianMusicPart
+                {
+                    Id = Guid.NewGuid(),
+                    MusicianId = musician.Id,
+                    MusicPartId = partId
+                }, cancellationToken);
+            }
+
+            await db.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/Queries/GetUser.cs
+++ b/src/SheetMusic.Api/Users/Queries/GetUser.cs
@@ -1,5 +1,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Errors;
 using System;
@@ -14,9 +16,9 @@ public class GetUser(Guid userId) : IRequest<GetUser.Result>
 {
     public Guid UserId { get; } = userId;
 
-    public record Result(ApplicationUser User, IReadOnlyList<string> Roles);
+    public record Result(ApplicationUser User, IReadOnlyList<string> Roles, IReadOnlyList<MusicPart> Parts);
 
-    public class Handler(UserManager<ApplicationUser> userManager) : IRequestHandler<GetUser, Result>
+    public class Handler(UserManager<ApplicationUser> userManager, SheetMusicContext db) : IRequestHandler<GetUser, Result>
     {
         public async Task<Result> Handle(GetUser request, CancellationToken cancellationToken)
         {
@@ -24,8 +26,16 @@ public class GetUser(Guid userId) : IRequest<GetUser.Result>
                 ?? throw new NotFoundError($"users/{request.UserId}", "User not found");
 
             var roles = await userManager.GetRolesAsync(user);
+            var parts = await db.Musicians
+                .Where(musician => musician.ApplicationUserId == request.UserId)
+                .SelectMany(musician => musician.MusicianMusicParts)
+                .Include(musicianPart => musicianPart.MusicPart)
+                .ThenInclude(part => part.Aliases)
+                .OrderBy(musicianPart => musicianPart.MusicPart.SortOrder)
+                .Select(musicianPart => musicianPart.MusicPart)
+                .ToListAsync(cancellationToken);
 
-            return new Result(user, roles.ToList());
+            return new Result(user, roles.ToList(), parts);
         }
     }
 }

--- a/src/SheetMusic.Api/Users/RequestModels/AssignPartsToUserRequest.cs
+++ b/src/SheetMusic.Api/Users/RequestModels/AssignPartsToUserRequest.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+
+namespace SheetMusic.Api.Users.RequestModels;
+
+public class AssignPartsToUserRequest
+{
+    /// <summary>
+    /// The identifiers of the parts to assign to the user.
+    /// </summary>
+    public IReadOnlyList<Guid> PartIds { get; set; } = [];
+
+    public class Validator : AbstractValidator<AssignPartsToUserRequest>
+    {
+        public Validator()
+        {
+            RuleFor(r => r.PartIds).NotNull();
+            RuleForEach(r => r.PartIds).NotEmpty();
+            RuleFor(r => r.PartIds).Must(partIds => partIds.Distinct().Count() == partIds.Count)
+                .When(r => r.PartIds is not null)
+                .WithMessage("Part identifiers must be unique.");
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/UsersController.cs
+++ b/src/SheetMusic.Api/Users/UsersController.cs
@@ -167,7 +167,25 @@ public class UsersController(UserManager<ApplicationUser> userManager, IMediator
 
         var result = await mediator.Send(new GetUser(id));
 
-        return Ok(new ApiUserDetail(result.User, result.Roles));
+        return Ok(new ApiUserDetail(result.User, result.Roles, result.Parts));
+    }
+
+    /// <summary>
+    /// Replaces the parts assigned to a user's musician record. Admin only.
+    /// </summary>
+    /// <param name="id">The guid of the user to assign parts to</param>
+    /// <param name="request">The identifiers of the parts to assign</param>
+    /// <response code="200">Parts were assigned successfully</response>
+    /// <response code="400">The supplied part identifiers are invalid</response>
+    /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Administrator)</response>
+    /// <response code="404">User or one or more parts were not found</response>
+    [Authorize(AuthPolicy.Admin)]
+    [HttpPut("users/{id}/parts")]
+    public async Task<IActionResult> AssignPartsAsync(Guid id, [FromBody] AssignPartsToUserRequest request)
+    {
+        await mediator.Send(new AssignPartsToUser(id, request.PartIds));
+        return Ok();
     }
 
     /// <summary>

--- a/src/SheetMusic.Api/Users/ViewModels/ApiUserDetail.cs
+++ b/src/SheetMusic.Api/Users/ViewModels/ApiUserDetail.cs
@@ -1,4 +1,5 @@
 using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Parts.ViewModels;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,10 +7,12 @@ namespace SheetMusic.Api.Users.ViewModels;
 
 public class ApiUserDetail : ApiUser
 {
-    public ApiUserDetail(ApplicationUser user, IEnumerable<string> roles) : base(user)
+    public ApiUserDetail(ApplicationUser user, IEnumerable<string> roles, IEnumerable<MusicPart> parts) : base(user)
     {
         Roles = roles.ToList();
+        Parts = parts.Select(part => new ApiPart(part)).ToList();
     }
 
     public IReadOnlyList<string> Roles { get; }
+    public IReadOnlyList<ApiPart> Parts { get; }
 }


### PR DESCRIPTION
## Summary
- add an admin endpoint to replace a musician's assigned parts
- return assigned parts when retrieving a user
- validate assignment payloads and cover assignment behavior with integration tests

## Testing
- dotnet test src/SheetMusic.Api.Test/SheetMusic.Api.Test.csproj --filter "FullyQualifiedName~V2_AssignParts" --no-restore