### PR TITLE
fix(users): include roles in user list

### DIFF
--- a/src/SheetMusic.Api.Test/Users/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Users/UserTests.cs
@@ -8,6 +8,7 @@ using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
 using SheetMusic.Api.Test.Infrastructure.TestCollections;
 using SheetMusic.Api.Test.Utility;
+using SheetMusic.Api.Users.Authorization;
 using SheetMusic.Api.Users.Errors;
 using SheetMusic.Api.Users.ViewModels;
 using System;
@@ -18,6 +19,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -263,9 +265,27 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     public async Task V2_GetAllUsers_ShouldBeSuccessful_WhenAdmin()
     {
         var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+        var part = new MusicPart { Id = Guid.NewGuid(), Name = "List test part", Indexable = true };
+
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            await db.MusicParts.AddAsync(part);
+            await db.SaveChangesAsync();
+        }
+
+        var assignResponse = await client.PutAsJsonAsync($"users/{TestUser.Testesen.Identifier}/parts", new { PartIds = new[] { part.Id } });
+        assignResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var response = await client.GetAsync("users");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var testesen = document.RootElement.EnumerateArray()
+            .Single(user => user.GetProperty("id").GetGuid() == TestUser.Testesen.Identifier);
+        var roles = testesen.GetProperty("roles").EnumerateArray().Select(role => role.GetString());
+        roles.Should().BeEquivalentTo([Roles.Musikant, Roles.Arkivleser]);
+        testesen.GetProperty("parts").EnumerateArray().Select(part => part.GetProperty("id").GetGuid()).Should().Equal(part.Id);
     }
 
     [Fact]

--- a/src/SheetMusic.Api/Users/Queries/GetUserCollection.cs
+++ b/src/SheetMusic.Api/Users/Queries/GetUserCollection.cs
@@ -1,6 +1,6 @@
 using MediatR;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using System.Collections.Generic;
 using System.Threading;
@@ -8,13 +8,30 @@ using System.Threading.Tasks;
 
 namespace SheetMusic.Api.Users.Queries;
 
-public class GetUserCollection : IRequest<IReadOnlyList<ApplicationUser>>
+public class GetUserCollection : IRequest<IReadOnlyList<GetUserCollection.Result>>
 {
-    public class Handler(UserManager<ApplicationUser> userManager) : IRequestHandler<GetUserCollection, IReadOnlyList<ApplicationUser>>
+    public record Result(ApplicationUser User, IReadOnlyList<string> Roles, IReadOnlyList<MusicPart> Parts);
+
+    public class Handler(SheetMusicContext db) : IRequestHandler<GetUserCollection, IReadOnlyList<Result>>
     {
-        public async Task<IReadOnlyList<ApplicationUser>> Handle(GetUserCollection request, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<Result>> Handle(GetUserCollection request, CancellationToken cancellationToken)
         {
-            return await userManager.Users.ToListAsync(cancellationToken);
+            return await db.Users
+                .Select(user => new Result(
+                    user,
+                    db.UserRoles
+                        .Where(userRole => userRole.UserId == user.Id)
+                        .Join(db.Roles, userRole => userRole.RoleId, role => role.Id, (_, role) => role.Name!)
+                        .ToList(),
+                    db.Musicians
+                        .Where(musician => musician.ApplicationUserId == user.Id)
+                        .SelectMany(musician => musician.MusicianMusicParts)
+                        .Include(musicianPart => musicianPart.MusicPart)
+                        .ThenInclude(part => part.Aliases)
+                        .OrderBy(musicianPart => musicianPart.MusicPart.SortOrder)
+                        .Select(musicianPart => musicianPart.MusicPart)
+                        .ToList()))
+                .ToListAsync(cancellationToken);
         }
     }
 }

--- a/src/SheetMusic.Api/Users/UsersController.cs
+++ b/src/SheetMusic.Api/Users/UsersController.cs
@@ -130,7 +130,7 @@ public class UsersController(UserManager<ApplicationUser> userManager, IMediator
     {
         var users = await mediator.Send(new GetUserCollection());
 
-        return Ok(users.Select(u => new ApiUser(u)));
+        return Ok(users.Select(u => new ApiUserDetail(u.User, u.Roles, u.Parts)));
     }
 
     /// <summary>


### PR DESCRIPTION
Summary: Include Identity roles in GET /users, use a batched EF Core projection, and add multi-role list-response coverage. Testing: dotnet test focused UserTests (71 passed). Closes #291.