### PR TITLE
fix(projects): show inactive projects to project managers

### DIFF
--- a/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
@@ -132,7 +132,7 @@ public class ProjectTests(SheetMusicWebAppFactory factory) : IClassFixture<Sheet
     }
 
     [Fact]
-    public async Task GetCatalogResources_ShouldRespectActiveProjectScope_ForMusikantAndArkivleser()
+    public async Task GetCatalogResources_ShouldRespectActiveProjectScope_ForMusikantArkivleserAndProsjektleder()
     {
         var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
         var activeProject = new
@@ -190,6 +190,9 @@ public class ProjectTests(SheetMusicWebAppFactory factory) : IClassFixture<Sheet
         (await dualRoleClient.GetAsync($"sheetmusic/sets/{inactiveSet.Id}")).StatusCode.Should().Be(HttpStatusCode.OK);
 
         var noCatalogAccessClient = factory.CreateClientWithTestToken(TestUser.Prosjektleder);
+        var prosjektlederProjects = await noCatalogAccessClient.GetFromJsonAsync<List<ApiProject>>("projects", JsonDefaults.Options);
+        prosjektlederProjects!.Should().Contain(project => project.Name == activeProject.Name);
+        prosjektlederProjects.Should().Contain(project => project.Name == inactiveProject.Name);
         (await noCatalogAccessClient.GetAsync($"sheetmusic/sets/{activeSet.Id}")).StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 

--- a/src/SheetMusic.Api/Users/Authorization/CatalogAccessService.cs
+++ b/src/SheetMusic.Api/Users/Authorization/CatalogAccessService.cs
@@ -34,7 +34,7 @@ public class CatalogAccessService(SheetMusicContext db, IHttpContextAccessor htt
 
     /// <summary>Gets whether the current user can access the specified project.</summary>
     public bool CanAccessProject(DateTime startDate, DateTime endDate) =>
-        HasFullLibraryAccess() || (IsMusikant() && startDate <= DateTime.UtcNow && endDate >= DateTime.UtcNow);
+        HasFullLibraryAccess() || IsProsjektleder() || (IsMusikant() && startDate <= DateTime.UtcNow && endDate >= DateTime.UtcNow);
 
     /// <summary>Filters set identifiers to the catalogue resources visible to the current user.</summary>
     public async Task<HashSet<Guid>> GetAccessibleSetIdsAsync(IEnumerable<Guid> setIds, CancellationToken cancellationToken = default)
@@ -55,6 +55,8 @@ public class CatalogAccessService(SheetMusicContext db, IHttpContextAccessor htt
     }
 
     private bool HasFullLibraryAccess() => User.IsInRole(Roles.Admin) || User.IsInRole(Roles.Noteansvarlig) || User.IsInRole(Roles.Arkivleser);
+
+    private bool IsProsjektleder() => User.IsInRole(Roles.Prosjektleder);
 
     private bool IsMusikant() => User.IsInRole(Roles.Musikant);
 


### PR DESCRIPTION
## Summary
- Allow Prosjektleder to view active and inactive projects
- Keep Musikant visibility limited to active projects and direct set access restricted
- Add integration coverage for both role scopes

## Testing
- dotnet test .\\SheetMusic.Api.Test\\SheetMusic.Api.Test.csproj --filter FullyQualifiedName~SheetMusic.Api.Test.Tests.Projects.ProjectTests.GetCatalogResources_ShouldRespectActiveProjectScope_ForMusikantArkivleserAndProsjektleder --no-restore