### PR TITLE
fix(deploy): reconcile existing sql role users

### DIFF
--- a/src/SheetMusic.Api.Test/Infrastructure/SqlRoleScriptCompatibilityResolverTests.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/SqlRoleScriptCompatibilityResolverTests.cs
@@ -1,5 +1,6 @@
 extern alias AppHost;
 
+using System;
 using FluentAssertions;
 using Xunit;
 
@@ -14,6 +15,16 @@ public class SqlRoleScriptCompatibilityResolverTests
             Install-Module -Name SqlServer -RequiredVersion 22.3.0 -Force -AllowClobber -Scope CurrentUser
             Import-Module SqlServer
 
+            $sqlCmd = @"
+            DECLARE @name SYSNAME = '$principalName';
+            DECLARE @id UNIQUEIDENTIFIER = '$id';
+            DECLARE @castId NVARCHAR(MAX) = CONVERT(VARCHAR(MAX), CONVERT (VARBINARY(16), @id), 1);
+            DECLARE @cmd NVARCHAR(MAX) = N'CREATE USER [' + @name + '] WITH SID = ' + @castId + ', TYPE = E;'
+            EXEC (@cmd);
+            DECLARE @role1 NVARCHAR(MAX) = N'ALTER ROLE db_owner ADD MEMBER [' + @name + ']';
+            EXEC (@role1);
+            "@
+
             $connectionString = "Server=tcp:${sqlServerFqdn},1433;Initial Catalog=${sqlDatabaseName};Authentication=Active Directory Default;"
             Invoke-Sqlcmd -ConnectionString $connectionString -Query $sqlCmd
             """;
@@ -24,6 +35,73 @@ public class SqlRoleScriptCompatibilityResolverTests
             .And.NotContain("Invoke-Sqlcmd")
             .And.Contain("Get-AzAccessToken -ResourceUrl \"https://database.windows.net/\"")
             .And.Contain("System.Data.SqlClient.SqlConnection")
-            .And.Contain("Encrypt=True;TrustServerCertificate=False;");
+            .And.Contain("Encrypt=True;TrustServerCertificate=False;")
+            .And.Contain("IF @existingSid IS NULL")
+            .And.Contain("sys.database_role_members")
+            .And.Contain("@existingPrincipalType")
+            .And.Contain("THROW 50000")
+            .And.NotContain("DECLARE @cmd NVARCHAR(MAX)");
+    }
+
+    [Fact]
+    public void RewriteScriptContent_Throws_WhenGeneratedCreateUserBatchIsUnrecognized()
+    {
+        const string scriptContent = """
+            $sqlCmd = @"
+            CREATE -- unsupported user
+            USER [unexpected] WITH SID = 0x00, TYPE = E;
+            "@
+            Invoke-Sqlcmd -ConnectionString $connectionString -Query $sqlCmd
+            """;
+
+        var rewrite = () => AppHost::SqlRoleScriptCompatibilityResolver.RewriteScriptContent(scriptContent);
+
+        rewrite.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unsupported CREATE USER batch*");
+    }
+
+    [Fact]
+    public void RewriteScriptContent_RewritesLegacyBatch_WhenGeneratedSqlUsesLowercaseKeywords()
+    {
+        const string scriptContent = """
+            $sqlCmd = @"
+            declare @name sysname = '$principalName';
+            declare @id uniqueidentifier = '$id';
+            declare @castId nvarchar(max) = convert(varchar(max), convert (varbinary(16), @id), 1);
+            declare @cmd nvarchar(max) = N'create user [' + @name + '] with sid = ' + @castId + ', type = E;'
+            exec (@cmd);
+            declare @role1 nvarchar(max) = N'alter role db_owner add member [' + @name + ']';
+            exec (@role1);
+            "@
+            Invoke-Sqlcmd -ConnectionString $connectionString -Query $sqlCmd
+            """;
+
+        var rewritten = AppHost::SqlRoleScriptCompatibilityResolver.RewriteScriptContent(scriptContent);
+
+        rewritten.Should().Contain("IF @existingSid IS NULL")
+            .And.NotContain("declare @cmd nvarchar(max)");
+    }
+
+    [Fact]
+    public void RewriteScriptContent_Throws_WhenRecognizedAndUnrecognizedCreateUserBatchesAreMixed()
+    {
+        const string scriptContent = """
+            $sqlCmd = @"
+            DECLARE @name SYSNAME = '$principalName';
+            DECLARE @id UNIQUEIDENTIFIER = '$id';
+            DECLARE @castId NVARCHAR(MAX) = CONVERT(VARCHAR(MAX), CONVERT (VARBINARY(16), @id), 1);
+            DECLARE @cmd NVARCHAR(MAX) = N'CREATE USER [' + @name + '] WITH SID = ' + @castId + ', TYPE = E;'
+            EXEC (@cmd);
+            DECLARE @role1 NVARCHAR(MAX) = N'ALTER ROLE db_owner ADD MEMBER [' + @name + ']';
+            EXEC (@role1);
+            CREATE USER [unexpected] WITH SID = 0x00, TYPE = E;
+            "@
+            Invoke-Sqlcmd -ConnectionString $connectionString -Query $sqlCmd
+            """;
+
+        var rewrite = () => AppHost::SqlRoleScriptCompatibilityResolver.RewriteScriptContent(scriptContent);
+
+        rewrite.Should().Throw<InvalidOperationException>()
+            .WithMessage("*unsupported CREATE USER batch*");
     }
 }

--- a/src/SheetMusic.AppHost/AppHost.cs
+++ b/src/SheetMusic.AppHost/AppHost.cs
@@ -357,6 +357,18 @@ internal sealed class SqlRoleScriptCompatibilityResolver : InfrastructureResolve
         @"(?m)^\s*Install-Module -Name SqlServer.*\r?\n\s*Import-Module SqlServer\s*\r?\n?",
         RegexOptions.CultureInvariant);
 
+    private static readonly Regex LegacySqlBatch = new(
+        @"(?s)DECLARE @name SYSNAME = '\$principalName';.*?EXEC \(@role1\);",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex CreateUser = new(
+        @"\bCREATE\s+USER\b",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex SqlComments = new(
+        @"(?m:--[^\r\n]*)|(?s:/\*.*?\*/)",
+        RegexOptions.CultureInvariant);
+
     private const string SqlConnectionString = """
         $connectionString = "Server=tcp:${sqlServerFqdn},1433;Initial Catalog=${sqlDatabaseName};Authentication=Active Directory Default;"
         """;
@@ -366,6 +378,44 @@ internal sealed class SqlRoleScriptCompatibilityResolver : InfrastructureResolve
         """;
 
     private const string InvokeSqlCommand = "Invoke-Sqlcmd -ConnectionString $connectionString -Query $sqlCmd";
+
+    private const string IdempotentSqlBatch = """
+        DECLARE @name SYSNAME = '$principalName';
+        DECLARE @id UNIQUEIDENTIFIER = '$id';
+        DECLARE @sid VARBINARY(16) = CONVERT(VARBINARY(16), @id);
+        DECLARE @castId NVARCHAR(MAX) = CONVERT(VARCHAR(MAX), @sid, 1);
+        DECLARE @existingPrincipalType CHAR(1) = (
+            SELECT type FROM sys.database_principals WHERE name = @name);
+        DECLARE @existingSid VARBINARY(85) = (
+            SELECT sid FROM sys.database_principals WHERE name = @name AND type = 'E');
+
+        IF @existingPrincipalType IS NOT NULL AND @existingPrincipalType <> 'E'
+            THROW 50000, 'A non-external-user database principal already uses the managed identity name.', 1;
+
+        IF @existingSid IS NOT NULL AND @existingSid <> @sid
+        BEGIN
+            DECLARE @dropCmd NVARCHAR(MAX) = N'DROP USER ' + QUOTENAME(@name);
+            EXEC (@dropCmd);
+            SET @existingSid = NULL;
+        END
+
+        IF @existingSid IS NULL
+        BEGIN
+            DECLARE @createCmd NVARCHAR(MAX) = N'CREATE USER ' + QUOTENAME(@name) + N' WITH SID = ' + @castId + N', TYPE = E;';
+            EXEC (@createCmd);
+        END
+
+        IF NOT EXISTS (
+            SELECT 1
+            FROM sys.database_role_members AS members
+            INNER JOIN sys.database_principals AS roles ON roles.principal_id = members.role_principal_id
+            INNER JOIN sys.database_principals AS principals ON principals.principal_id = members.member_principal_id
+            WHERE roles.name = N'db_owner' AND principals.name = @name)
+        BEGIN
+            DECLARE @roleCmd NVARCHAR(MAX) = N'ALTER ROLE db_owner ADD MEMBER ' + QUOTENAME(@name);
+            EXEC (@roleCmd);
+        END
+        """;
 
     private const string ExecuteSqlCommand = """
         $tokenResponse = Get-AzAccessToken -ResourceUrl "https://database.windows.net/"
@@ -409,6 +459,14 @@ internal sealed class SqlRoleScriptCompatibilityResolver : InfrastructureResolve
     {
         var rewritten = scriptContent.Replace(SqlConnectionString, SqlClientConnectionString, StringComparison.Ordinal);
         rewritten = SqlServerModule.Replace(rewritten, string.Empty);
+
+        var executableSql = SqlComments.Replace(rewritten, " ");
+        if (CreateUser.Matches(executableSql).Count != LegacySqlBatch.Matches(rewritten).Count)
+        {
+            throw new InvalidOperationException("The generated Azure SQL role script has an unsupported CREATE USER batch.");
+        }
+
+        rewritten = LegacySqlBatch.Replace(rewritten, IdempotentSqlBatch);
 
         return rewritten.Replace(InvokeSqlCommand, ExecuteSqlCommand, StringComparison.Ordinal);
     }


### PR DESCRIPTION
## Summary
- rewrite Aspire 13.4.6 Azure SQL role scripts to reconcile existing Entra managed-identity users instead of unconditionally creating them
- preserve users with the current SID, replace stale Entra users, and grant db_owner only when membership is missing
- fail closed for unsupported generated CREATE USER batches

## Validation
- dotnet test src/SheetMusic.Api.Test/SheetMusic.Api.Test.csproj --no-restore --filter FullyQualifiedName~SqlRoleScriptCompatibilityResolverTests
- aspire publish --output-path <temp> --non-interactive
- final code review found no blocking issues