### PR TITLE
Include project dates in set expansion

### DIFF
--- a/.github/agents/sheetmusic-dev.agent.md
+++ b/.github/agents/sheetmusic-dev.agent.md
@@ -108,6 +108,7 @@ When changing existing behavior (bug fix, field addition, small tweak) outside t
 - DO NOT mix commands and queries
 - DO NOT skip validation
 - DO NOT create generic exceptions
+- In PowerShell, use a here-string or `` `n`` for multiline GitHub issue bodies; never use literal `\n`.
 - DO NOT skip or merely suggest tests - implement them as part of the change
 - DO NOT add new files to the legacy artifact-type folders (`Controllers/`, `CQRS/`, `Repositories/`, `Database/Entities/`)
 - DO NOT place domain-specific types in `Shared/`

--- a/src/SheetMusic.Api.Test/Sets/GetSetListTests.cs
+++ b/src/SheetMusic.Api.Test/Sets/GetSetListTests.cs
@@ -644,6 +644,9 @@ public class GetSetListTests(SheetMusicWebAppFactory factory) : IClassFixture<Sh
         musikantItems.Should().ContainSingle();
         var musikantProjects = musikantItems[0].Projects ?? throw new InvalidOperationException("Expanded projects should be included in the response.");
         musikantProjects.Should().ContainSingle(summary => summary.Id == activeProject.Id && summary.Name == activeProject.Name);
+        var musikantProject = musikantProjects.Single();
+        musikantProject.StartDate.Should().Be(activeProject.StartDate);
+        musikantProject.EndDate.Should().Be(activeProject.EndDate);
 
         var adminItems = await GetSetsAsync(adminClient, $"{Search(set.Title!)}&$expand=projects&api-version={apiVersion}");
         adminItems.Should().ContainSingle();

--- a/src/SheetMusic.Api/Sets/ViewModels/ApiProjectSummary.cs
+++ b/src/SheetMusic.Api/Sets/ViewModels/ApiProjectSummary.cs
@@ -16,6 +16,8 @@ public class ApiProjectSummary
     {
         Id = project.Id;
         Name = project.Name;
+        StartDate = project.StartDate;
+        EndDate = project.EndDate;
     }
 
     /// <summary>
@@ -27,4 +29,14 @@ public class ApiProjectSummary
     /// Project name.
     /// </summary>
     public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Project start date.
+    /// </summary>
+    public DateTime StartDate { get; set; }
+
+    /// <summary>
+    /// Project end date.
+    /// </summary>
+    public DateTime EndDate { get; set; }
 }


### PR DESCRIPTION
Summary: Expose StartDate and EndDate on projects returned by the set projects expansion. Add integration coverage for both API versions 1.0 and 2.0. Testing: dotnet test SheetMusic.Api.Test/SheetMusic.Api.Test.csproj --no-restore --filter FullyQualifiedName~GetSetList_WithExpandProjects_ShouldIncludeVisibleProjectSummaries_ForEveryApiVersion