### PR TITLE
fix: keep untitled sets last when sorting by title

### DIFF
--- a/src/SheetMusic.Api.Test/Sets/GetSetListTests.cs
+++ b/src/SheetMusic.Api.Test/Sets/GetSetListTests.cs
@@ -1,4 +1,7 @@
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using SheetMusic.Api.Database;
+using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
 using SheetMusic.Api.Test.Infrastructure.TestCollections;
@@ -455,6 +458,35 @@ public class GetSetListTests(SheetMusicWebAppFactory factory) : IClassFixture<Sh
         var items = await GetSetsAsync(client, $"{Search(Marker)}&$orderby=title");
 
         items.Select(i => i.Title).Should().BeInAscendingOrder(StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetSetList_WithTitleOrderBy_ShouldPlaceUntitledLegacySetsAfterTitledSets()
+    {
+        using var isolatedFactory = new SheetMusicWebAppFactory();
+        var client = isolatedFactory.CreateClientWithTestToken(TestUser.Testesen);
+        var legacySet = new SheetMusicSet(999999, "");
+
+        using (var scope = isolatedFactory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            db.SheetMusicSets.AddRange(
+                new SheetMusicSet(999997, "Issue326 Alfa"),
+                new SheetMusicSet(999998, "Issue326 Bravo"));
+            db.SheetMusicSets.Add(legacySet);
+            await db.SaveChangesAsync();
+        }
+
+        var items = await GetSetsAsync(client, "?$orderby=title asc");
+
+        items.Last().Id.Should().Be(legacySet.Id);
+        items.Take(items.Count - 1).Should().OnlyContain(item => !string.IsNullOrEmpty(item.Title));
+
+        var pagedItems = await GetSetsAsync(client, "?$orderby=title asc&$skip=2&$top=1");
+        pagedItems.Should().ContainSingle(item => item.Id == legacySet.Id);
+
+        var descendingItems = await GetSetsAsync(client, "?$orderby=title desc");
+        descendingItems.Last().Id.Should().Be(legacySet.Id);
     }
 
     [Fact]

--- a/src/SheetMusic.Api/OData/Extensions/ODataQueryParamsExtensions.cs
+++ b/src/SheetMusic.Api/OData/Extensions/ODataQueryParamsExtensions.cs
@@ -40,7 +40,7 @@ public static class ODataQueryParamsExtensions
     /// convention as <see cref="ApplyODataFilters{T}"/>. Multiple order-by fields are applied in the
     /// order they were supplied.
     /// </summary>
-    public static IQueryable<T> ApplyODataOrderBy<T>(this IQueryable<T> items, ODataQueryParams queryParams, Action<ODataFieldMapping<T>> mapFields)
+    public static IQueryable<T> ApplyODataOrderBy<T>(this IQueryable<T> items, ODataQueryParams queryParams, Action<ODataFieldMapping<T>> mapFields, bool preserveExistingOrder = false)
     {
         if (!queryParams.OrderBy.Any())
             return items;
@@ -48,7 +48,7 @@ public static class ODataQueryParamsExtensions
         var fieldMapping = new ODataFieldMapping<T>();
         mapFields(fieldMapping);
 
-        IOrderedQueryable<T>? ordered = null;
+        IOrderedQueryable<T>? ordered = preserveExistingOrder ? items as IOrderedQueryable<T> : null;
         foreach (var option in queryParams.OrderBy)
         {
             LambdaExpression keySelector;

--- a/src/SheetMusic.Api/Sets/Queries/GetSets.cs
+++ b/src/SheetMusic.Api/Sets/Queries/GetSets.cs
@@ -52,9 +52,17 @@ public class GetSets(ODataQueryParams queryParams, Guid? categoryId = null, bool
             if (request.CategoryId.HasValue)
                 baseQuery = baseQuery.Where(set => set.Categories.Any(c => c.CategoryId == request.CategoryId.Value));
 
-            baseQuery = request.QueryParams.OrderBy.Any()
-                ? baseQuery.ApplyODataOrderBy(request.QueryParams, FieldMapping)
-                : baseQuery.OrderBy(s => s.ArchiveNumber);
+            if (request.QueryParams.OrderBy.Any())
+            {
+                if (string.Equals(request.QueryParams.OrderBy[0].Field, "title", StringComparison.OrdinalIgnoreCase))
+                    baseQuery = baseQuery.OrderBy(s => s.Title == "").ApplyODataOrderBy(request.QueryParams, FieldMapping, preserveExistingOrder: true);
+                else
+                    baseQuery = baseQuery.ApplyODataOrderBy(request.QueryParams, FieldMapping);
+            }
+            else
+            {
+                baseQuery = baseQuery.OrderBy(s => s.ArchiveNumber);
+            }
 
             if (request.QueryParams.Skip.HasValue)
                 baseQuery = baseQuery.Skip(request.QueryParams.Skip.Value);


### PR DESCRIPTION
## Summary
- Keep legacy untitled sheet-music sets after titled entries when sorting by title.
- Preserve the ordering only for the title-specific pre-sort path.
- Add integration coverage for ascending, descending, and paged title sorting.

Closes #326

## Tests
- dotnet test src/SheetMusic.Api.Test/SheetMusic.Api.Test.csproj --filter FullyQualifiedName~GetSetListTests --no-restore --verbosity minimal