### PR TITLE
feat(sets): change part assignment

### DIFF
--- a/src/SheetMusic.Api.Test/Sets/SetTests.cs
+++ b/src/SheetMusic.Api.Test/Sets/SetTests.cs
@@ -1,9 +1,16 @@
 using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using PdfSharp.Pdf;
+using SheetMusic.Api.BlobStorage;
+using SheetMusic.Api.Database;
+using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Parts.ViewModels;
 using SheetMusic.Api.Sets;
+using SheetMusic.Api.Sets.Commands;
 using SheetMusic.Api.Sets.Errors;
+using SheetMusic.Api.Sets.Queries;
 using SheetMusic.Api.Sets.Services;
 using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
@@ -18,6 +25,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -537,6 +545,150 @@ public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusi
     }
 
     [Fact]
+    public async Task ChangePart_ShouldReplaceAssignmentAndPreserveRelationship_WhenReplacementPartIsSelected()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var testSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        var parts = await new PartDataBuilder(adminClient).WithParts(2).ProvisionAsync();
+        var originalPartOnSet = await AddPartToSetAsync(testSet, parts[0]);
+        var originalPdf = Encoding.UTF8.GetBytes("original PDF content");
+        byte[]? replacementPdf = null;
+        factory.BlobMock.Setup(blob => blob.GetMusicPartContentStreamAsync(
+                It.Is<PartRelatedToSet>(relation => relation.SetId == testSet.Id && relation.PartId == parts[0].Id)))
+            .ReturnsAsync(new MemoryStream(originalPdf));
+        factory.BlobMock.Setup(blob => blob.AddMusicPartContentAsync(
+                It.Is<PartRelatedToSet>(relation => relation.SetId == testSet.Id && relation.PartId == parts[1].Id),
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<PartRelatedToSet, Stream, CancellationToken>((_, content, _) => replacementPdf = ReadContent(content))
+            .Returns(Task.CompletedTask);
+        factory.BlobMock.Invocations.Clear();
+
+        var response = await ChangePartAsync(adminClient, testSet.Id, parts[0].Id, parts[1].Id);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var changedPart = await response.Content.ReadFromJsonAsync<ApiSetPart>(JsonDefaults.Options);
+        changedPart!.RelationshipId.Should().Be(originalPartOnSet!.RelationshipId);
+        changedPart.MusicPartId.Should().Be(parts[1].Id);
+        (await adminClient.GetAsync($"sheetmusic/sets/{testSet.Id}/parts/{parts[0].Id}")).StatusCode.Should().Be(HttpStatusCode.NotFound);
+        replacementPdf.Should().Equal(originalPdf);
+        factory.BlobMock.Verify(blob => blob.DeletePartContentAsync(
+            It.Is<PartRelatedToSet>(relation => relation.SetId == testSet.Id && relation.PartId == parts[0].Id)), Times.Once);
+    }
+
+    [Fact]
+    public async Task ChangePart_ShouldReturnBadRequest_WhenReplacementPartIdentifierIsMissing()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var testSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        var part = await new PartDataBuilder(adminClient).ProvisionSinglePartAsync();
+        var originalPartOnSet = await AddPartToSetAsync(testSet, part);
+
+        var response = await adminClient.PutAsJsonAsync($"sheetmusic/sets/{testSet.Id}/parts/{part.Id}?api-version=2.0", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var partOnSet = await adminClient.GetFromJsonAsync<ApiSetPart>($"sheetmusic/sets/{testSet.Id}/parts/{part.Id}");
+        partOnSet!.RelationshipId.Should().Be(originalPartOnSet!.RelationshipId);
+    }
+
+    [Fact]
+    public async Task ChangePart_ShouldReturnUnauthorized_WhenUnauthenticated()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var testSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        var parts = await new PartDataBuilder(adminClient).WithParts(2).ProvisionAsync();
+        await AddPartToSetAsync(testSet, parts[0]);
+
+        var response = await ChangePartAsync(factory.CreateClient(), testSet.Id, parts[0].Id, parts[1].Id);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ChangePart_ShouldReturnForbidden_WhenUserCannotManageMusic()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var testSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        var parts = await new PartDataBuilder(adminClient).WithParts(2).ProvisionAsync();
+        await AddPartToSetAsync(testSet, parts[0]);
+
+        var response = await ChangePartAsync(factory.CreateClientWithTestToken(TestUser.Testesen), testSet.Id, parts[0].Id, parts[1].Id);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ChangePart_ShouldReturnConflict_WhenReplacementPartIsAlreadyAssigned()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var testSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        var parts = await new PartDataBuilder(adminClient).WithParts(2).ProvisionAsync();
+        var originalPartOnSet = await AddPartToSetAsync(testSet, parts[0]);
+        await AddPartToSetAsync(testSet, parts[1]);
+
+        var response = await ChangePartAsync(adminClient, testSet.Id, parts[0].Id, parts[1].Id);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var partOnSet = await adminClient.GetFromJsonAsync<ApiSetPart>($"sheetmusic/sets/{testSet.Id}/parts/{parts[0].Id}");
+        partOnSet!.RelationshipId.Should().Be(originalPartOnSet!.RelationshipId);
+    }
+
+    [Fact]
+    public async Task ChangePart_ShouldReturnNotFound_WhenReplacementPartDoesNotExist()
+    {
+        var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
+        var testSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
+        var part = await new PartDataBuilder(adminClient).ProvisionSinglePartAsync();
+        var originalPartOnSet = await AddPartToSetAsync(testSet, part);
+
+        var response = await adminClient.PutAsJsonAsync($"sheetmusic/sets/{testSet.Id}/parts/{part.Id}?api-version=2.0", new { PartIdentifier = Guid.NewGuid() });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var partOnSet = await adminClient.GetFromJsonAsync<ApiSetPart>($"sheetmusic/sets/{testSet.Id}/parts/{part.Id}");
+        partOnSet!.RelationshipId.Should().Be(originalPartOnSet!.RelationshipId);
+    }
+
+    [Fact]
+    public async Task ChangePart_ShouldDeleteStagedReplacementPdf_WhenDatabaseSaveFails()
+    {
+        var options = new DbContextOptionsBuilder<SheetMusicContext>()
+            .UseInMemoryDatabase($"ChangePartSaveFailure-{Guid.NewGuid()}")
+            .Options;
+        var set = new SheetMusicSet(1, "Test set");
+        var currentPart = new MusicPart { Id = Guid.NewGuid(), Name = "Current", Indexable = true };
+        var replacementPart = new MusicPart { Id = Guid.NewGuid(), Name = "Replacement", Indexable = true };
+        var assignment = new SheetMusicPart { Id = Guid.NewGuid(), SetId = set.Id, MusicPartId = currentPart.Id };
+
+        await using var db = new FailingSaveChangesContext(options);
+        await db.AddRangeAsync(set, currentPart, replacementPart, assignment);
+        await db.SaveChangesAsync();
+        db.FailSaves = true;
+
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(instance => instance.Send(It.IsAny<GetPartOnSet>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(assignment);
+        mediator.Setup(instance => instance.Send(It.IsAny<SheetMusic.Api.Parts.Queries.GetMusicPart>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(replacementPart);
+        var blobClient = new Mock<IBlobClient>();
+        blobClient.Setup(instance => instance.GetMusicPartContentStreamAsync(It.IsAny<PartRelatedToSet>()))
+            .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("original PDF content")));
+        blobClient.Setup(instance => instance.AddMusicPartContentAsync(It.IsAny<PartRelatedToSet>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var handler = new ChangePartOnSet.Handler(db, mediator.Object, blobClient.Object);
+
+        var action = () => handler.Handle(new ChangePartOnSet(set.Id.ToString(), currentPart.Id.ToString(), replacementPart.Id.ToString()), CancellationToken.None);
+
+        await action.Should().ThrowAsync<InvalidOperationException>();
+        blobClient.Verify(instance => instance.DeletePartContentAsync(
+            It.Is<PartRelatedToSet>(relation => relation.SetId == set.Id && relation.PartId == replacementPart.Id)), Times.Once);
+        assignment.MusicPartId.Should().Be(replacementPart.Id);
+
+        await using var verificationDb = new SheetMusicContext(options);
+        var persistedAssignment = await verificationDb.SheetMusicParts.SingleAsync();
+        persistedAssignment.MusicPartId.Should().Be(currentPart.Id);
+    }
+
+    [Fact]
     public async Task UploadPartsForSet_ShouldMarkUnknownZipEntryAsMissingPart_AndNotCreatePart()
     {
         var adminClient = factory.CreateClientWithTestToken(TestUser.Administrator);
@@ -666,6 +818,31 @@ public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusi
         var setPart = await response.Content.ReadFromJsonAsync<ApiSetPart>(JsonDefaults.Options);
 
         return setPart;
+    }
+
+    private static Task<HttpResponseMessage> ChangePartAsync(HttpClient client, Guid setId, Guid currentPartId, Guid replacementPartId)
+    {
+        return client.PutAsJsonAsync($"sheetmusic/sets/{setId}/parts/{currentPartId}?api-version=2.0", new { PartIdentifier = replacementPartId });
+    }
+
+    private static byte[] ReadContent(Stream content)
+    {
+        using var copy = new MemoryStream();
+        content.CopyTo(copy);
+        return copy.ToArray();
+    }
+
+    private sealed class FailingSaveChangesContext(DbContextOptions<SheetMusicContext> options) : SheetMusicContext(options)
+    {
+        public bool FailSaves { get; set; }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (FailSaves)
+                throw new InvalidOperationException("Database save failed");
+
+            return base.SaveChangesAsync(cancellationToken);
+        }
     }
 
     private async Task<string> GetDownloadTokenAsync(ApiSet set)

--- a/src/SheetMusic.Api/Sets/Commands/ChangePartOnSet.cs
+++ b/src/SheetMusic.Api/Sets/Commands/ChangePartOnSet.cs
@@ -1,0 +1,57 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using SheetMusic.Api.BlobStorage;
+using SheetMusic.Api.Database;
+using SheetMusic.Api.Errors;
+using SheetMusic.Api.Parts.Queries;
+using SheetMusic.Api.Sets.Errors;
+using SheetMusic.Api.Sets.Queries;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Sets.Commands;
+
+public class ChangePartOnSet(string setIdentifier, string currentPartIdentifier, string replacementPartIdentifier) : IRequest
+{
+    public string SetIdentifier { get; } = setIdentifier;
+    public string CurrentPartIdentifier { get; } = currentPartIdentifier;
+    public string ReplacementPartIdentifier { get; } = replacementPartIdentifier;
+
+    public class Handler(SheetMusicContext db, IMediator mediator, IBlobClient blobClient) : IRequestHandler<ChangePartOnSet>
+    {
+        public async Task Handle(ChangePartOnSet request, CancellationToken cancellationToken)
+        {
+            var partOnSet = await mediator.Send(new GetPartOnSet(request.SetIdentifier, request.CurrentPartIdentifier), cancellationToken)
+                ?? throw new NotFoundError($"{request.SetIdentifier}/{request.CurrentPartIdentifier}", "Part is not assigned to the set");
+
+            var replacementPart = await mediator.Send(new GetMusicPart(request.ReplacementPartIdentifier), cancellationToken)
+                ?? throw new NotFoundError(request.ReplacementPartIdentifier, "Replacement part was not found");
+
+            if (await db.SheetMusicParts.AnyAsync(part => part.SetId == partOnSet.SetId && part.MusicPartId == replacementPart.Id, cancellationToken))
+            {
+                var set = await mediator.Send(new GetSet(request.SetIdentifier), cancellationToken)
+                    ?? throw new NotFoundError(request.SetIdentifier, "Set was not found");
+                throw new MusicSetPartAlreadyAddedError(set.Title, replacementPart.Name);
+            }
+
+            var currentBlob = new PartRelatedToSet(partOnSet.SetId, partOnSet.MusicPartId);
+            var replacementBlob = new PartRelatedToSet(partOnSet.SetId, replacementPart.Id);
+
+            await using var currentContent = await blobClient.GetMusicPartContentStreamAsync(currentBlob);
+            await blobClient.AddMusicPartContentAsync(replacementBlob, currentContent, cancellationToken);
+
+            try
+            {
+                partOnSet.MusicPartId = replacementPart.Id;
+                await db.SaveChangesAsync(cancellationToken);
+            }
+            catch
+            {
+                await blobClient.DeletePartContentAsync(replacementBlob);
+                throw;
+            }
+
+            await blobClient.DeletePartContentAsync(currentBlob);
+        }
+    }
+}

--- a/src/SheetMusic.Api/Sets/RequestModels/ChangePartRequest.cs
+++ b/src/SheetMusic.Api/Sets/RequestModels/ChangePartRequest.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace SheetMusic.Api.Sets.RequestModels;
+
+public class ChangePartRequest
+{
+    /// <summary>
+    /// Identifier (guid or name) of the part that replaces the current assignment.
+    /// </summary>
+    public string PartIdentifier { get; set; } = null!;
+
+    public class Validator : AbstractValidator<ChangePartRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.PartIdentifier)
+                .NotEmpty()
+                .WithMessage("A replacement part identifier (id or name) is required.");
+        }
+    }
+}

--- a/src/SheetMusic.Api/Sets/SheetMusicController.cs
+++ b/src/SheetMusic.Api/Sets/SheetMusicController.cs
@@ -531,6 +531,34 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         }
     }
 
+    /// <summary>
+    /// Changes an existing part assignment on a set to the selected replacement part.
+    /// </summary>
+    /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title.</param>
+    /// <param name="partIdentifier">A value uniquely identifying the currently assigned part. Either guid or part name.</param>
+    /// <param name="request">The selected replacement part.</param>
+    /// <returns>The updated set-part assignment.</returns>
+    /// <response code="200">The part assignment was changed successfully.</response>
+    /// <response code="400">The replacement part identifier is missing or invalid.</response>
+    /// <response code="404">Set, current part, replacement part, or the relationship between them was not found.</response>
+    /// <response code="409">The replacement part is already assigned to the set.</response>
+    /// <response code="401">Authorization header is invalid or missing.</response>
+    /// <response code="403">Forbidden. User does not have required privileges (Noteansvarlig or Administrator).</response>
+    [Authorize(AuthPolicy.ManageMusic)]
+    [Produces("application/json", Type = typeof(ApiSheetMusicPart))]
+    [HttpPut("sets/{setIdentifier}/parts/{partIdentifier}")]
+    [MapToApiVersion("2.0")]
+    public async Task<ActionResult<ApiSheetMusicPart>> ChangePart(string setIdentifier, string partIdentifier, ChangePartRequest request)
+    {
+        await mediator.Send(new ChangePartOnSet(setIdentifier, partIdentifier, request.PartIdentifier));
+        var changedPart = await mediator.Send(new GetPartOnSet(setIdentifier, request.PartIdentifier));
+
+        if (changedPart is null)
+            throw new NotFoundError($"{setIdentifier}/{request.PartIdentifier}", "Changed part assignment was not found");
+
+        return new ApiSheetMusicPart(changedPart);
+    }
+
     /// <summary>Creates a new set and imports recognized parts from a combined score PDF.</summary>
     /// <param name="cancellationToken">Cancellation token for the split operation.</param>
     /// <returns>The created set.</returns>


### PR DESCRIPTION
Closes #365

## Summary
- add a v2 JSON PUT endpoint that changes an existing set part to a user-selected replacement part
- preserve the set-part relationship identity and transfer its PDF to the replacement part storage key
- reject missing or already-assigned replacement parts without changing the existing assignment
- compensate by deleting a staged replacement PDF if the database update fails

## Tests
- dotnet test ./src/SheetMusic.Api.Test/SheetMusic.Api.Test.csproj --filter FullyQualifiedName~ChangePart --no-restore