### PR TITLE
feat(users): add profile picture API

### DIFF
--- a/src/SheetMusic.Api.Test/Users/UserTests.cs
+++ b/src/SheetMusic.Api.Test/Users/UserTests.cs
@@ -11,8 +11,11 @@ using SheetMusic.Api.Test.Utility;
 using SheetMusic.Api.Users.Authorization;
 using SheetMusic.Api.Users.Errors;
 using SheetMusic.Api.Users.ViewModels;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -20,7 +23,9 @@ using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using Xunit;
 
 namespace SheetMusic.Api.Test.Users;
@@ -417,6 +422,190 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     [Fact]
+    public async Task V2_GetProfilePicture_ShouldReturnUnauthorized_WhenAnonymous()
+    {
+        var client = CreateV2Client();
+
+        var response = await client.GetAsync($"users/{TestUser.Testesen.Identifier}/profile-picture");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task V2_UploadProfilePicture_ShouldReturnForbidden_WhenUserUpdatesAnotherUser()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Musikant);
+
+        var response = await client.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", CreateProfilePictureContent());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task V2_UploadProfilePicture_ShouldReturnBadRequest_WhenImageIsMalformed()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Testesen);
+        using var content = new MultipartFormDataContent
+        {
+            { new ByteArrayContent(Encoding.UTF8.GetBytes("not an image")), "file", "picture.png" },
+            { new StringContent("0"), "x" },
+            { new StringContent("0"), "y" },
+            { new StringContent("1"), "size" }
+        };
+
+        var response = await client.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_UploadProfilePicture_ShouldReturnBadRequest_WhenFileIsMissing()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Testesen);
+        using var content = new MultipartFormDataContent
+        {
+            { new StringContent("0"), "x" },
+            { new StringContent("0"), "y" },
+            { new StringContent("1"), "size" }
+        };
+
+        var response = await client.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task V2_UploadProfilePicture_ShouldExposeNewVersionAndReturnWebp_WhenUserUpdatesOwnPicture()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Testesen);
+        var blobs = ConfigureProfilePictureBlobs();
+
+        var upload = await client.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", CreateProfilePictureContent());
+        upload.StatusCode.Should().Be(HttpStatusCode.OK, await upload.Content.ReadAsStringAsync());
+        var uploaded = await upload.Content.ReadFromJsonAsync<ApiProfilePicture>(JsonDefaults.Options);
+
+        using var userDocument = JsonDocument.Parse(await client.GetStringAsync($"users/{TestUser.Testesen.Identifier}"));
+        userDocument.RootElement.GetProperty("profilePicture").GetProperty("version").GetGuid().Should().Be(uploaded!.Version);
+
+        var get = await client.GetAsync($"users/{TestUser.Testesen.Identifier}/profile-picture");
+        get.StatusCode.Should().Be(HttpStatusCode.OK);
+        get.Content.Headers.ContentType!.MediaType.Should().Be("image/webp");
+        get.Headers.ETag!.Tag.Should().Be($"\"{uploaded.Version:N}\"");
+        blobs.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task V2_UploadProfilePicture_ShouldReplaceVersionAndDeleteSupersededBlob_WhenPictureAlreadyExists()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Testesen);
+        var blobs = ConfigureProfilePictureBlobs();
+
+        var first = await client.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", CreateProfilePictureContent());
+        var firstPicture = await first.Content.ReadFromJsonAsync<ApiProfilePicture>(JsonDefaults.Options);
+        var second = await client.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", CreateProfilePictureContent());
+        var secondPicture = await second.Content.ReadFromJsonAsync<ApiProfilePicture>(JsonDefaults.Options);
+
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        secondPicture!.Version.Should().NotBe(firstPicture!.Version);
+        blobs.Should().ContainSingle();
+        blobs.Keys.Single().Should().Contain(secondPicture.Version.ToString("N"));
+    }
+
+    [Fact]
+    public async Task V2_UploadProfilePicture_ShouldPersistReplacement_WhenSupersededBlobCleanupFails()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Testesen);
+        ConfigureProfilePictureBlobs();
+        var first = await client.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", CreateProfilePictureContent());
+        var firstPicture = await first.Content.ReadFromJsonAsync<ApiProfilePicture>(JsonDefaults.Options);
+        factory.BlobMock.Setup(blobClient => blobClient.DeleteProfilePictureAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Blob storage is unavailable"));
+
+        var second = await client.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", CreateProfilePictureContent());
+        var secondPicture = await second.Content.ReadFromJsonAsync<ApiProfilePicture>(JsonDefaults.Options);
+
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        secondPicture!.Version.Should().NotBe(firstPicture!.Version);
+    }
+
+    [Fact]
+    public async Task V2_UploadProfilePicture_ShouldKeepOnlyCurrentBlob_WhenUploadsAreConcurrent()
+    {
+        var firstClient = CreateV2ClientWithTestToken(TestUser.Testesen);
+        var secondClient = CreateV2ClientWithTestToken(TestUser.Testesen);
+        var blobs = ConfigureProfilePictureBlobs();
+
+        var uploads = await Task.WhenAll(
+            firstClient.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", CreateProfilePictureContent()),
+            secondClient.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", CreateProfilePictureContent()));
+        var responses = await Task.WhenAll(uploads.Select(response => response.Content.ReadAsStringAsync()));
+
+        uploads.Select(response => response.StatusCode).Should().BeEquivalentTo([HttpStatusCode.OK, HttpStatusCode.Conflict], string.Join("; ", responses));
+        blobs.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task V2_GetProfilePicture_ShouldReturnNotFound_WhenUserPictureBlobIsMissing()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Testesen);
+        ConfigureProfilePictureBlobs();
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+            var user = await userManager.FindByIdAsync(TestUser.Testesen.Identifier.ToString());
+            user!.ProfilePictureBlobName = "profile-pictures/missing.webp";
+            user.ProfilePictureVersion = Guid.NewGuid();
+            (await userManager.UpdateAsync(user)).Succeeded.Should().BeTrue();
+        }
+
+        var response = await client.GetAsync($"users/{TestUser.Testesen.Identifier}/profile-picture");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task V2_RemoveProfilePicture_ShouldDeletePictureAndClearUserState_WhenUserRemovesOwnPicture()
+    {
+        var client = CreateV2ClientWithTestToken(TestUser.Testesen);
+        var blobs = ConfigureProfilePictureBlobs();
+        await client.PutAsync($"users/{TestUser.Testesen.Identifier}/profile-picture", CreateProfilePictureContent());
+
+        var remove = await client.DeleteAsync($"users/{TestUser.Testesen.Identifier}/profile-picture");
+        using var userDocument = JsonDocument.Parse(await client.GetStringAsync($"users/{TestUser.Testesen.Identifier}"));
+        var get = await client.GetAsync($"users/{TestUser.Testesen.Identifier}/profile-picture");
+
+        remove.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        userDocument.RootElement.GetProperty("profilePicture").ValueKind.Should().Be(JsonValueKind.Null);
+        get.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        blobs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task V2_DeleteUser_ShouldDeleteProfilePictureBlob_WhenHardDeletingUser()
+    {
+        var anonymousClient = CreateV2Client();
+        var blobs = ConfigureProfilePictureBlobs();
+        const string blobName = "profile-pictures/hard-delete/picture.webp";
+        blobs[blobName] = [1, 2, 3];
+        var (userId, _) = await RegisterInactiveUserAsync(anonymousClient, "hard-delete-profile-picture");
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+            var user = await userManager.FindByIdAsync(userId.ToString());
+            user!.ProfilePictureBlobName = blobName;
+            user.ProfilePictureVersion = Guid.NewGuid();
+            (await userManager.UpdateAsync(user)).Succeeded.Should().BeTrue();
+        }
+
+        var client = CreateV2ClientWithTestToken(TestUser.Administrator);
+        var response = await client.DeleteAsync($"users/{userId}?hardDelete=true");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        blobs.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task V2_AssignParts_ShouldBeForbidden_WhenNonAdmin()
     {
         var client = CreateV2ClientWithTestToken(TestUser.Musikant);
@@ -677,6 +866,43 @@ public class UserTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMus
     }
 
     private record ApiUserDetailModel(IReadOnlyList<ApiPartModel> Parts);
+
+    private Dictionary<string, byte[]> ConfigureProfilePictureBlobs()
+    {
+        var blobs = new Dictionary<string, byte[]>();
+        factory.BlobMock.Setup(client => client.AddProfilePictureAsync(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Returns<string, Stream, CancellationToken>(async (blobName, content, cancellationToken) =>
+            {
+                using var copy = new MemoryStream();
+                await content.CopyToAsync(copy, cancellationToken);
+                blobs.Add(blobName, copy.ToArray());
+            });
+        factory.BlobMock.Setup(client => client.GetProfilePictureAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((blobName, _) => blobs.TryGetValue(blobName, out var content)
+                ? Task.FromResult<Stream>(new MemoryStream(content))
+                : Task.FromException<Stream>(new FileNotFoundException("Profile picture blob was not found", blobName)));
+        factory.BlobMock.Setup(client => client.DeleteProfilePictureAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((blobName, _) =>
+            {
+                blobs.Remove(blobName);
+                return Task.CompletedTask;
+            });
+        return blobs;
+    }
+
+    private static MultipartFormDataContent CreateProfilePictureContent()
+    {
+        using var image = new Image<Rgba32>(1, 1, new Rgba32(255, 0, 0));
+        using var imageContent = new MemoryStream();
+        image.SaveAsPng(imageContent);
+
+        var content = new MultipartFormDataContent();
+        content.Add(new ByteArrayContent(imageContent.ToArray()), "file", "picture.png");
+        content.Add(new StringContent("0"), "x");
+        content.Add(new StringContent("0"), "y");
+        content.Add(new StringContent("1"), "size");
+        return content;
+    }
 
     private record ApiPartModel(Guid Id);
 

--- a/src/SheetMusic.Api/BlobStorage/BlobClient.cs
+++ b/src/SheetMusic.Api/BlobStorage/BlobClient.cs
@@ -148,5 +148,58 @@ public class BlobClient(BlobServiceClient blobServiceClient, IConfiguration conf
         var blob = GetBlob(identifier);
         await blob.DeleteIfExistsAsync();
     }
+
+    public async Task AddProfilePictureAsync(string blobName, Stream contentStream, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await EnsureContainerExistsAsync(cancellationToken);
+            await GetContainer().GetBlobClient(blobName).UploadAsync(contentStream, overwrite: false, cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new BlobInteractionError("Error occurred when uploading profile picture", ex);
+        }
+    }
+
+    public async Task<Stream> GetProfilePictureAsync(string blobName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await GetContainer().GetBlobClient(blobName).OpenReadAsync(cancellationToken: cancellationToken);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            throw new FileNotFoundException("Profile picture blob was not found", blobName, ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new BlobInteractionError("Error occurred when reading profile picture", ex);
+        }
+    }
+
+    public async Task DeleteProfilePictureAsync(string blobName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await GetContainer().GetBlobClient(blobName).DeleteIfExistsAsync(cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new BlobInteractionError("Error occurred when deleting profile picture", ex);
+        }
+    }
 }
 

--- a/src/SheetMusic.Api/BlobStorage/IBlobClient.cs
+++ b/src/SheetMusic.Api/BlobStorage/IBlobClient.cs
@@ -15,4 +15,7 @@ public interface IBlobClient
     Task DeleteSetContentAsync(Guid id);
     Task<bool> HasPdfFileAsync(PartRelatedToSet identifier);
     Task DeletePartContentAsync(PartRelatedToSet identifier);
+    Task AddProfilePictureAsync(string blobName, Stream contentStream, CancellationToken cancellationToken);
+    Task<Stream> GetProfilePictureAsync(string blobName, CancellationToken cancellationToken);
+    Task DeleteProfilePictureAsync(string blobName, CancellationToken cancellationToken);
 }

--- a/src/SheetMusic.Api/Database/Entities/ApplicationUser.cs
+++ b/src/SheetMusic.Api/Database/Entities/ApplicationUser.cs
@@ -5,6 +5,8 @@ namespace SheetMusic.Api.Database.Entities;
 public class ApplicationUser : IdentityUser<Guid>
 {
     public string? DisplayName { get; set; }
+    public string? ProfilePictureBlobName { get; set; }
+    public Guid? ProfilePictureVersion { get; set; }
     public bool Inactive { get; set; } = true;
     public Musician? Musician { get; set; }
 }

--- a/src/SheetMusic.Api/Database/SheetMusicContext.cs
+++ b/src/SheetMusic.Api/Database/SheetMusicContext.cs
@@ -37,6 +37,10 @@ public class SheetMusicContext(DbContextOptions<SheetMusicContext> options) : Id
             .WithOne(m => m.ApplicationUser)
             .HasForeignKey<Musician>(m => m.ApplicationUserId);
 
+        modelBuilder.Entity<ApplicationUser>()
+            .Property(user => user.ProfilePictureVersion)
+            .IsConcurrencyToken();
+
         modelBuilder.Entity<RefreshToken>()
             .HasIndex(rt => rt.Token)
             .IsUnique();

--- a/src/SheetMusic.Api/Migrations/20260818142048_AddUserProfilePicture.Designer.cs
+++ b/src/SheetMusic.Api/Migrations/20260818142048_AddUserProfilePicture.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SheetMusic.Api.Database;
 
@@ -11,9 +12,11 @@ using SheetMusic.Api.Database;
 namespace SheetMusic.Api.Migrations
 {
     [DbContext(typeof(SheetMusicContext))]
-    partial class SheetMusicContextModelSnapshot : ModelSnapshot
+    [Migration("20260818142048_AddUserProfilePicture")]
+    partial class AddUserProfilePicture
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -206,7 +209,6 @@ namespace SheetMusic.Api.Migrations
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<Guid?>("ProfilePictureVersion")
-                        .IsConcurrencyToken()
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("SecurityStamp")

--- a/src/SheetMusic.Api/Migrations/20260818142048_AddUserProfilePicture.cs
+++ b/src/SheetMusic.Api/Migrations/20260818142048_AddUserProfilePicture.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SheetMusic.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserProfilePicture : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProfilePictureBlobName",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ProfilePictureVersion",
+                table: "AspNetUsers",
+                type: "uniqueidentifier",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProfilePictureBlobName",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "ProfilePictureVersion",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/src/SheetMusic.Api/Migrations/20260818143050_AddProfilePictureConcurrency.Designer.cs
+++ b/src/SheetMusic.Api/Migrations/20260818143050_AddProfilePictureConcurrency.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SheetMusic.Api.Database;
 
@@ -11,9 +12,11 @@ using SheetMusic.Api.Database;
 namespace SheetMusic.Api.Migrations
 {
     [DbContext(typeof(SheetMusicContext))]
-    partial class SheetMusicContextModelSnapshot : ModelSnapshot
+    [Migration("20260818143050_AddProfilePictureConcurrency")]
+    partial class AddProfilePictureConcurrency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SheetMusic.Api/Migrations/20260818143050_AddProfilePictureConcurrency.cs
+++ b/src/SheetMusic.Api/Migrations/20260818143050_AddProfilePictureConcurrency.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SheetMusic.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProfilePictureConcurrency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/SheetMusic.Api/Program.cs
+++ b/src/SheetMusic.Api/Program.cs
@@ -13,6 +13,7 @@ using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Errors;
 using SheetMusic.Api.Search;
 using SheetMusic.Api.Sets.Services;
+using SheetMusic.Api.Users.Services;
 using System.Linq;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -65,6 +66,7 @@ builder.AddAzureBlobServiceClient("blobs");
 // admin key - see IndexAdminService, which no longer has a Search:AdminKey to manage.
 builder.AddAzureSearchClient("search");
 builder.Services.AddSingleton<IBlobClient, SheetMusic.Api.BlobStorage.BlobClient>();
+builder.Services.AddSingleton<ProfilePictureProcessor>();
 builder.Services.AddSingleton<IIndexAdminService, IndexAdminService>();
 
 // See AddSheetMusicDataProtection for why the key ring is persisted to blob storage rather than the

--- a/src/SheetMusic.Api/SheetMusic.Api.csproj
+++ b/src/SheetMusic.Api/SheetMusic.Api.csproj
@@ -43,6 +43,7 @@
 		<PackageReference Include="PdfSharp" Version="6.2.4" />
 		<PackageReference Include="Resend" Version="0.8.0" />
 		<PackageReference Include="Scalar.AspNetCore" Version="2.16.20" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SheetMusic.Api/Users/Commands/DeleteUser.cs
+++ b/src/SheetMusic.Api/Users/Commands/DeleteUser.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using SheetMusic.Api.BlobStorage;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
 using SheetMusic.Api.Errors;
@@ -17,7 +18,7 @@ public class DeleteUser(Guid userId, bool hardDelete = false) : IRequest
     public Guid UserId { get; } = userId;
     public bool HardDelete { get; } = hardDelete;
 
-    public class Handler(UserManager<ApplicationUser> userManager, SheetMusicContext db) : IRequestHandler<DeleteUser>
+    public class Handler(UserManager<ApplicationUser> userManager, SheetMusicContext db, IBlobClient blobClient, ILogger<Handler> logger) : IRequestHandler<DeleteUser>
     {
         public async Task Handle(DeleteUser request, CancellationToken cancellationToken)
         {
@@ -33,6 +34,22 @@ public class DeleteUser(Guid userId, bool hardDelete = false) : IRequest
 
             if (!result.Succeeded)
                 throw new IdentityOperationError(result.Errors.Select(e => e.Description));
+
+            if (request.HardDelete && user.ProfilePictureBlobName is not null)
+            {
+                try
+                {
+                    await blobClient.DeleteProfilePictureAsync(user.ProfilePictureBlobName, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Could not delete profile picture blob {BlobName} for deleted user {UserId}", user.ProfilePictureBlobName, user.Id);
+                }
+            }
 
             async Task<IdentityResult> DeactivateAsync(ApplicationUser userToDeactivate)
             {

--- a/src/SheetMusic.Api/Users/Commands/RemoveProfilePicture.cs
+++ b/src/SheetMusic.Api/Users/Commands/RemoveProfilePicture.cs
@@ -1,0 +1,63 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using SheetMusic.Api.BlobStorage;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Errors;
+using SheetMusic.Api.Users.Authorization;
+using SheetMusic.Api.Users.Errors;
+using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Commands;
+
+public sealed class RemoveProfilePicture(Guid userId, ClaimsPrincipal authenticatedUser) : IRequest
+{
+    public Guid UserId { get; } = userId;
+    public ClaimsPrincipal AuthenticatedUser { get; } = authenticatedUser;
+
+    public sealed class Handler(UserManager<ApplicationUser> userManager, IBlobClient blobClient, ILogger<Handler> logger) : IRequestHandler<RemoveProfilePicture>
+    {
+        public async Task Handle(RemoveProfilePicture request, CancellationToken cancellationToken)
+        {
+            if (!Guid.TryParse(request.AuthenticatedUser.FindFirst(ClaimTypes.Name)?.Value, out var authenticatedUserId))
+                throw new UnableToIdentifyUserError();
+
+            var authenticatedUser = await userManager.FindByIdAsync(authenticatedUserId.ToString());
+            var isAdmin = authenticatedUser is not null && await userManager.IsInRoleAsync(authenticatedUser, Roles.Admin);
+            if (authenticatedUserId != request.UserId && !isAdmin)
+                throw new ProfilePictureForbiddenError();
+
+            var user = await userManager.FindByIdAsync(request.UserId.ToString())
+                ?? throw new NotFoundError($"users/{request.UserId}", "User not found");
+            if (user.ProfilePictureBlobName is null)
+                throw new NotFoundError($"users/{request.UserId}/profile-picture", "Profile picture not found");
+
+            var blobName = user.ProfilePictureBlobName;
+            user.ProfilePictureBlobName = null;
+            user.ProfilePictureVersion = null;
+            var result = await userManager.UpdateAsync(user);
+            if (!result.Succeeded)
+            {
+                if (result.Errors.Any(error => error.Code == "ConcurrencyFailure"))
+                    throw new ProfilePictureUpdateConflictError();
+
+                throw new IdentityOperationError(result.Errors.Select(error => error.Description));
+            }
+
+            try
+            {
+                await blobClient.DeleteProfilePictureAsync(blobName, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Could not delete removed profile picture blob {BlobName}", blobName);
+            }
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/Commands/UploadProfilePicture.cs
+++ b/src/SheetMusic.Api/Users/Commands/UploadProfilePicture.cs
@@ -1,0 +1,86 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using SheetMusic.Api.BlobStorage;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Errors;
+using SheetMusic.Api.Users.Authorization;
+using SheetMusic.Api.Users.Errors;
+using SheetMusic.Api.Users.RequestModels;
+using SheetMusic.Api.Users.Services;
+using System;
+using System.IO;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Commands;
+
+public sealed class UploadProfilePicture(Guid userId, ClaimsPrincipal authenticatedUser, Stream content, ProfilePictureCropRequest crop) : IRequest<Guid>
+{
+    public Guid UserId { get; } = userId;
+    public ClaimsPrincipal AuthenticatedUser { get; } = authenticatedUser;
+    public Stream Content { get; } = content;
+    public ProfilePictureCropRequest Crop { get; } = crop;
+
+    public sealed class Handler(UserManager<ApplicationUser> userManager, IBlobClient blobClient, ProfilePictureProcessor processor, ILogger<Handler> logger) : IRequestHandler<UploadProfilePicture, Guid>
+    {
+        public async Task<Guid> Handle(UploadProfilePicture request, CancellationToken cancellationToken)
+        {
+            var authenticatedUserId = GetAuthenticatedUserId(request.AuthenticatedUser);
+            var authenticatedUser = await userManager.FindByIdAsync(authenticatedUserId.ToString());
+            var isAdmin = authenticatedUser is not null && await userManager.IsInRoleAsync(authenticatedUser, Roles.Admin);
+            if (authenticatedUserId != request.UserId && !isAdmin)
+                throw new ProfilePictureForbiddenError();
+
+            var user = await userManager.FindByIdAsync(request.UserId.ToString())
+                ?? throw new NotFoundError($"users/{request.UserId}", "User not found");
+            await using var processedPicture = await processor.ProcessAsync(request.Content, request.Crop, cancellationToken);
+
+            var newVersion = Guid.NewGuid();
+            var newBlobName = $"profile-pictures/{user.Id}/{newVersion:N}.webp";
+            await blobClient.AddProfilePictureAsync(newBlobName, processedPicture, cancellationToken);
+
+            var previousBlobName = user.ProfilePictureBlobName;
+            user.ProfilePictureBlobName = newBlobName;
+            user.ProfilePictureVersion = newVersion;
+            var result = await userManager.UpdateAsync(user);
+            if (!result.Succeeded)
+            {
+                await DeleteBestEffortAsync(newBlobName, cancellationToken);
+                if (result.Errors.Any(error => error.Code == "ConcurrencyFailure"))
+                    throw new ProfilePictureUpdateConflictError();
+
+                throw new IdentityOperationError(result.Errors.Select(error => error.Description));
+            }
+
+            if (previousBlobName is not null)
+                await DeleteBestEffortAsync(previousBlobName, cancellationToken);
+
+            return newVersion;
+        }
+
+        private static Guid GetAuthenticatedUserId(ClaimsPrincipal authenticatedUser)
+        {
+            if (!Guid.TryParse(authenticatedUser.FindFirst(ClaimTypes.Name)?.Value, out var userId))
+                throw new UnableToIdentifyUserError();
+
+            return userId;
+        }
+
+        private async Task DeleteBestEffortAsync(string blobName, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await blobClient.DeleteProfilePictureAsync(blobName, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Could not delete superseded profile picture blob {BlobName}", blobName);
+            }
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/Errors/InvalidProfilePictureError.cs
+++ b/src/SheetMusic.Api/Users/Errors/InvalidProfilePictureError.cs
@@ -1,0 +1,9 @@
+using SheetMusic.Api.Errors;
+using System.Net;
+
+namespace SheetMusic.Api.Users.Errors;
+
+public sealed class InvalidProfilePictureError(string message) : ExceptionBase(message)
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+}

--- a/src/SheetMusic.Api/Users/Errors/ProfilePictureForbiddenError.cs
+++ b/src/SheetMusic.Api/Users/Errors/ProfilePictureForbiddenError.cs
@@ -1,0 +1,9 @@
+using SheetMusic.Api.Errors;
+using System.Net;
+
+namespace SheetMusic.Api.Users.Errors;
+
+public sealed class ProfilePictureForbiddenError() : ExceptionBase("Only the user or an Administrator can modify this profile picture")
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.Forbidden;
+}

--- a/src/SheetMusic.Api/Users/Errors/ProfilePictureUpdateConflictError.cs
+++ b/src/SheetMusic.Api/Users/Errors/ProfilePictureUpdateConflictError.cs
@@ -1,0 +1,9 @@
+using SheetMusic.Api.Errors;
+using System.Net;
+
+namespace SheetMusic.Api.Users.Errors;
+
+public sealed class ProfilePictureUpdateConflictError() : ExceptionBase("The profile picture was changed by another request. Retry the operation.")
+{
+    public override HttpStatusCode StatusCode => HttpStatusCode.Conflict;
+}

--- a/src/SheetMusic.Api/Users/Queries/GetProfilePicture.cs
+++ b/src/SheetMusic.Api/Users/Queries/GetProfilePicture.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using SheetMusic.Api.BlobStorage;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Errors;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Queries;
+
+public sealed class GetProfilePicture(Guid userId) : IRequest<GetProfilePicture.Result>
+{
+    public Guid UserId { get; } = userId;
+
+    public sealed record Result(Stream Content, Guid Version);
+
+    public sealed class Handler(UserManager<ApplicationUser> userManager, IBlobClient blobClient) : IRequestHandler<GetProfilePicture, Result>
+    {
+        public async Task<Result> Handle(GetProfilePicture request, CancellationToken cancellationToken)
+        {
+            var user = await userManager.FindByIdAsync(request.UserId.ToString())
+                ?? throw new NotFoundError($"users/{request.UserId}", "User not found");
+            if (user.ProfilePictureBlobName is null || user.ProfilePictureVersion is null)
+                throw new NotFoundError($"users/{request.UserId}/profile-picture", "Profile picture not found");
+
+            try
+            {
+                var content = await blobClient.GetProfilePictureAsync(user.ProfilePictureBlobName, cancellationToken);
+                return new Result(content, user.ProfilePictureVersion.Value);
+            }
+            catch (FileNotFoundException)
+            {
+                throw new NotFoundError($"users/{request.UserId}/profile-picture", "Profile picture not found");
+            }
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/RequestModels/ProfilePictureCropRequest.cs
+++ b/src/SheetMusic.Api/Users/RequestModels/ProfilePictureCropRequest.cs
@@ -1,0 +1,8 @@
+namespace SheetMusic.Api.Users.RequestModels;
+
+public class ProfilePictureCropRequest
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Size { get; set; }
+}

--- a/src/SheetMusic.Api/Users/RequestModels/ProfilePictureUploadRequest.cs
+++ b/src/SheetMusic.Api/Users/RequestModels/ProfilePictureUploadRequest.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+
+namespace SheetMusic.Api.Users.RequestModels;
+
+public sealed class ProfilePictureUploadRequest : ProfilePictureCropRequest
+{
+    public IFormFile File { get; set; } = null!;
+
+    public sealed class Validator : AbstractValidator<ProfilePictureUploadRequest>
+    {
+        public Validator()
+        {
+            RuleFor(request => request.File).NotNull().WithMessage("A profile picture file is required");
+        }
+    }
+}

--- a/src/SheetMusic.Api/Users/Services/ProfilePictureProcessor.cs
+++ b/src/SheetMusic.Api/Users/Services/ProfilePictureProcessor.cs
@@ -1,0 +1,106 @@
+using SheetMusic.Api.Users.Errors;
+using SheetMusic.Api.Users.RequestModels;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Webp;
+using SixLabors.ImageSharp.Processing;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SheetMusic.Api.Users.Services;
+
+public sealed class ProfilePictureProcessor
+{
+    public const int MaxFileSize = 5 * 1024 * 1024;
+    private const int MaxDimension = 4096;
+    private const int OutputDimension = 512;
+
+    public async Task<MemoryStream> ProcessAsync(Stream source, ProfilePictureCropRequest crop, CancellationToken cancellationToken)
+    {
+        await using var input = await CopyBoundedAsync(source, cancellationToken);
+        input.Position = 0;
+
+        IImageFormat format;
+        try
+        {
+            format = await Image.DetectFormatAsync(input, cancellationToken)
+                ?? throw new InvalidProfilePictureError("The uploaded file is not a supported image");
+        }
+        catch (InvalidProfilePictureError)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new InvalidProfilePictureError("The uploaded file is not a valid image");
+        }
+
+        if (format is not JpegFormat and not PngFormat and not WebpFormat)
+            throw new InvalidProfilePictureError("Profile pictures must be JPEG, PNG, or WebP images");
+
+        input.Position = 0;
+        try
+        {
+            using var image = await Image.LoadAsync(input, cancellationToken);
+            if (image.Width > MaxDimension || image.Height > MaxDimension)
+                throw new InvalidProfilePictureError($"Profile pictures cannot exceed {MaxDimension} x {MaxDimension} pixels");
+
+            if (image.Frames.Count != 1)
+                throw new InvalidProfilePictureError("Animated profile pictures are not supported");
+
+            image.Mutate(context => context.AutoOrient());
+            ValidateCrop(image.Width, image.Height, crop);
+            image.Mutate(context => context.Crop(new Rectangle(crop.X, crop.Y, crop.Size, crop.Size)).Resize(OutputDimension, OutputDimension));
+
+            var output = new MemoryStream();
+            await image.SaveAsWebpAsync(output, new WebpEncoder(), cancellationToken);
+            output.Position = 0;
+            return output;
+        }
+        catch (InvalidProfilePictureError)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new InvalidProfilePictureError("The uploaded file is not a valid image");
+        }
+    }
+
+    private static void ValidateCrop(int width, int height, ProfilePictureCropRequest crop)
+    {
+        if (crop.Size <= 0 || crop.X < 0 || crop.Y < 0 || crop.X > width - crop.Size || crop.Y > height - crop.Size)
+            throw new InvalidProfilePictureError("The submitted crop must be a square within the source image");
+    }
+
+    private static async Task<MemoryStream> CopyBoundedAsync(Stream source, CancellationToken cancellationToken)
+    {
+        var output = new MemoryStream();
+        var buffer = new byte[81920];
+        int read;
+        while ((read = await source.ReadAsync(buffer, cancellationToken)) > 0)
+        {
+            if (output.Length + read > MaxFileSize)
+            {
+                await output.DisposeAsync();
+                throw new InvalidProfilePictureError("Profile pictures cannot exceed 5 MB");
+            }
+
+            await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+        }
+
+        return output;
+    }
+}

--- a/src/SheetMusic.Api/Users/UsersController.cs
+++ b/src/SheetMusic.Api/Users/UsersController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Net.Http.Headers;
 using Microsoft.Extensions.Options;
 using SheetMusic.Api.Configuration;
 using SheetMusic.Api.Database.Entities;
@@ -13,6 +14,7 @@ using SheetMusic.Api.Users.Commands;
 using SheetMusic.Api.Users.Errors;
 using SheetMusic.Api.Users.Queries;
 using SheetMusic.Api.Users.RequestModels;
+using SheetMusic.Api.Users.Services;
 using SheetMusic.Api.Users.ViewModels;
 using System;
 using System.Linq;
@@ -101,6 +103,73 @@ public class UsersController(UserManager<ApplicationUser> userManager, IMediator
     {
         await mediator.Send(new UpdateUser(identifier, User, request));
         return Ok();
+    }
+
+    /// <summary>
+    /// Upload or replace a user's profile picture. Users may update their own picture; Administrators may update any user's picture.
+    /// </summary>
+    /// <param name="identifier">The guid of the user whose profile picture will be changed.</param>
+    /// <param name="request">The source image and square crop in post-orientation source image pixels.</param>
+    /// <param name="cancellationToken">The cancellation token for the upload operation.</param>
+    /// <response code="200">The new profile-picture version.</response>
+    /// <response code="400">The file is malformed, unsupported, too large, animated, or has an invalid crop.</response>
+    /// <response code="409">Another request changed this profile picture; retry the operation.</response>
+    /// <response code="401">Authorization header is invalid or missing.</response>
+    /// <response code="403">The caller is neither the user nor an Administrator.</response>
+    /// <response code="409">Another request changed this profile picture; retry the operation.</response>
+    /// <response code="404">User not found.</response>
+    [Consumes("multipart/form-data")]
+    [RequestSizeLimit(ProfilePictureProcessor.MaxFileSize)]
+    [RequestFormLimits(MultipartBodyLengthLimit = ProfilePictureProcessor.MaxFileSize)]
+    [HttpPut("users/{identifier:guid}/profile-picture")]
+    public async Task<ActionResult<ApiProfilePicture>> UploadProfilePictureAsync(Guid identifier, [FromForm] ProfilePictureUploadRequest request, CancellationToken cancellationToken)
+    {
+        if (request.File is null || request.File.Length == 0)
+            throw new InvalidProfilePictureError("A non-empty profile picture file is required");
+
+        await using var content = request.File.OpenReadStream();
+        var version = await mediator.Send(new UploadProfilePicture(identifier, User, content, request), cancellationToken);
+        return Ok(new ApiProfilePicture(version));
+    }
+
+    /// <summary>
+    /// Retrieve a user's profile picture. Any authenticated user may retrieve a current profile picture.
+    /// </summary>
+    /// <param name="identifier">The guid of the user whose profile picture will be returned.</param>
+    /// <param name="cancellationToken">The cancellation token for the download operation.</param>
+    /// <response code="200">The processed WebP profile picture.</response>
+    /// <response code="401">Authorization header is invalid or missing.</response>
+    /// <response code="404">User or profile picture not found.</response>
+    [HttpGet("users/{identifier:guid}/profile-picture")]
+    public async Task<IActionResult> GetProfilePictureAsync(Guid identifier, CancellationToken cancellationToken)
+    {
+        var picture = await mediator.Send(new GetProfilePicture(identifier), cancellationToken);
+        var entityTag = new EntityTagHeaderValue($"\"{picture.Version:N}\"");
+        if (Request.GetTypedHeaders().IfNoneMatch?.Any(tag => tag.Compare(entityTag, useStrongComparison: true)) == true)
+        {
+            await picture.Content.DisposeAsync();
+            return StatusCode((int)HttpStatusCode.NotModified);
+        }
+
+        Response.GetTypedHeaders().ETag = entityTag;
+        Response.Headers.CacheControl = "private, max-age=31536000, immutable";
+        return File(picture.Content, "image/webp");
+    }
+
+    /// <summary>
+    /// Remove a user's profile picture. Users may remove their own picture; Administrators may remove any user's picture.
+    /// </summary>
+    /// <param name="identifier">The guid of the user whose profile picture will be removed.</param>
+    /// <param name="cancellationToken">The cancellation token for the deletion operation.</param>
+    /// <response code="204">The profile picture was removed.</response>
+    /// <response code="401">Authorization header is invalid or missing.</response>
+    /// <response code="403">The caller is neither the user nor an Administrator.</response>
+    /// <response code="404">User or profile picture not found.</response>
+    [HttpDelete("users/{identifier:guid}/profile-picture")]
+    public async Task<IActionResult> RemoveProfilePictureAsync(Guid identifier, CancellationToken cancellationToken)
+    {
+        await mediator.Send(new RemoveProfilePicture(identifier, User), cancellationToken);
+        return NoContent();
     }
 
     /// <summary>

--- a/src/SheetMusic.Api/Users/ViewModels/ApiProfilePicture.cs
+++ b/src/SheetMusic.Api/Users/ViewModels/ApiProfilePicture.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace SheetMusic.Api.Users.ViewModels;
+
+public sealed class ApiProfilePicture(Guid version)
+{
+    public Guid Version { get; } = version;
+}

--- a/src/SheetMusic.Api/Users/ViewModels/ApiUser.cs
+++ b/src/SheetMusic.Api/Users/ViewModels/ApiUser.cs
@@ -13,10 +13,12 @@ public class ApiUser
         Name = user.DisplayName ?? user.UserName ?? null!;
         Email = user.Email ?? null!;
         Inactive = user.Inactive;
+        ProfilePicture = user.ProfilePictureVersion is { } version ? new ApiProfilePicture(version) : null;
     }
 
     public Guid Id { get; set; }
     public string Name { get; set; }
     public string Email { get; set; }
     public bool Inactive { get; set; }
+    public ApiProfilePicture? ProfilePicture { get; set; }
 }


### PR DESCRIPTION
## Summary
- Add authenticated upload, retrieval, replacement, and removal endpoints for private user profile pictures.
- Validate JPEG, PNG, and WebP uploads; apply square crops and normalize output to 512x512 WebP.
- Persist versioned profile-picture metadata, private blob lifecycle cleanup, cache validators, and optimistic concurrency handling.
- Add EF migrations and integration coverage for authorization, validation, replacement, cleanup, cache versions, missing blobs, and concurrent updates.

## Testing
- `dotnet test src/SheetMusic.Api.Test/SheetMusic.Api.Test.csproj --filter "FullyQualifiedName~SheetMusic.Api.Test.Users.UserTests"`