### PR TITLE
Filter Musikant catalogue access by assigned part groups

### DIFF
--- a/src/SheetMusic.Api.Test/Infrastructure/SheetMusicWebAppFactory.cs
+++ b/src/SheetMusic.Api.Test/Infrastructure/SheetMusicWebAppFactory.cs
@@ -73,8 +73,8 @@ public class SheetMusicWebAppFactory : WebApplicationFactory<Program>
             BlobMock = new Mock<IBlobClient>();
             BlobMock.Setup(b => b.GetMusicPartContentAsync(It.IsAny<PartRelatedToSet>()))
                 .ReturnsAsync(Array.Empty<byte>());
-            BlobMock.Setup(b => b.GetMusicPartContentStreamAsync(It.IsAny<PartRelatedToSet>()))
-                .ReturnsAsync(new MemoryStream());
+            BlobMock.Setup(b => b.GetMusicPartContentStreamAsync(It.IsAny<PartRelatedToSet>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new MemoryStream());
             BlobMock.Setup(b => b.HasPdfFileAsync(It.IsAny<PartRelatedToSet>()))
                 .ReturnsAsync(true);
             services.TryRemoveService<IBlobClient>();

--- a/src/SheetMusic.Api.Test/Sets/GetSetListTests.cs
+++ b/src/SheetMusic.Api.Test/Sets/GetSetListTests.cs
@@ -669,6 +669,19 @@ public class GetSetListTests(SheetMusicWebAppFactory factory) : IClassFixture<Sh
         var inactiveProject = await CreateProjectAsync(adminClient, "Inactive", DateTime.UtcNow.AddDays(-3), DateTime.UtcNow.AddDays(-2));
         await AssignSetToProjectAsync(adminClient, activeProject.Name, set.Id);
         await AssignSetToProjectAsync(adminClient, inactiveProject.Name, set.Id);
+        var assignedPart = await new PartDataBuilder(adminClient).ProvisionSinglePartAsync();
+        await AddPartToSetAsync(adminClient, set, assignedPart.Name);
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            db.Set<MusicianMusicPart>().Add(new MusicianMusicPart
+            {
+                Id = Guid.NewGuid(),
+                MusicianId = TestUser.Musikant.Identifier,
+                MusicPartId = assignedPart.Id
+            });
+            await db.SaveChangesAsync();
+        }
 
         var musikantClient = factory.CreateClientWithTestToken(TestUser.Musikant);
         var musikantItems = await GetSetsAsync(musikantClient, $"{Search(set.Title!)}&$expand=projects&api-version={apiVersion}");

--- a/src/SheetMusic.Api.Test/Sets/SetTests.cs
+++ b/src/SheetMusic.Api.Test/Sets/SetTests.cs
@@ -554,7 +554,8 @@ public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusi
         var originalPdf = Encoding.UTF8.GetBytes("original PDF content");
         byte[]? replacementPdf = null;
         factory.BlobMock.Setup(blob => blob.GetMusicPartContentStreamAsync(
-                It.Is<PartRelatedToSet>(relation => relation.SetId == testSet.Id && relation.PartId == parts[0].Id)))
+            It.Is<PartRelatedToSet>(relation => relation.SetId == testSet.Id && relation.PartId == parts[0].Id),
+            It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(originalPdf));
         factory.BlobMock.Setup(blob => blob.AddMusicPartContentAsync(
                 It.Is<PartRelatedToSet>(relation => relation.SetId == testSet.Id && relation.PartId == parts[1].Id),
@@ -670,7 +671,7 @@ public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusi
         mediator.Setup(instance => instance.Send(It.IsAny<SheetMusic.Api.Parts.Queries.GetMusicPart>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(replacementPart);
         var blobClient = new Mock<IBlobClient>();
-        blobClient.Setup(instance => instance.GetMusicPartContentStreamAsync(It.IsAny<PartRelatedToSet>()))
+        blobClient.Setup(instance => instance.GetMusicPartContentStreamAsync(It.IsAny<PartRelatedToSet>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes("original PDF content")));
         blobClient.Setup(instance => instance.AddMusicPartContentAsync(It.IsAny<PartRelatedToSet>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -772,7 +773,8 @@ public class SetTests(SheetMusicWebAppFactory factory) : IClassFixture<SheetMusi
             .ProvisionAsync();
 
         await UploadPartsAsync(parts, testSet);
-        factory.BlobMock.Setup(bm => bm.GetMusicPartContentStreamAsync(It.IsAny<PartRelatedToSet>())).ReturnsAsync(new MemoryStream());
+        factory.BlobMock.Setup(bm => bm.GetMusicPartContentStreamAsync(It.IsAny<PartRelatedToSet>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream());
 
         var token = await GetDownloadTokenAsync(testSet);
         var zipResponse = await adminClient.GetAsync($"sheetmusic/sets/{testSet.Id}/zip?downloadToken={token}");

--- a/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/Projects/ProjectTests.cs
@@ -1,4 +1,8 @@
 ﻿using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using SheetMusic.Api.Database;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Parts;
 using SheetMusic.Api.Projects.ViewModels;
 using SheetMusic.Api.Test.Infrastructure;
 using SheetMusic.Api.Test.Infrastructure.Authentication;
@@ -154,6 +158,29 @@ public class ProjectTests(SheetMusicWebAppFactory factory) : IClassFixture<Sheet
         var inactiveSet = await new SetDataBuilder(adminClient).ProvisionSingleSetAsync();
         await adminClient.PostAsJsonAsync($"projects/{activeProject.Name}/sets", new { SetIdentifiers = new[] { activeSet.Id.ToString() } });
         await adminClient.PostAsJsonAsync($"projects/{inactiveProject.Name}/sets", new { SetIdentifiers = new[] { inactiveSet.Id.ToString() } });
+
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            var assignedPart = new MusicPart
+            {
+                Id = Guid.NewGuid(),
+                Name = $"Project scope cornet {Guid.NewGuid():N}",
+                Indexable = false,
+                InstrumentGroup = InstrumentGroup.Kornett
+            };
+            db.MusicParts.Add(assignedPart);
+            db.SheetMusicParts.AddRange(
+                new SheetMusicPart { Id = Guid.NewGuid(), SetId = activeSet.Id, MusicPartId = assignedPart.Id },
+                new SheetMusicPart { Id = Guid.NewGuid(), SetId = inactiveSet.Id, MusicPartId = assignedPart.Id });
+            db.Set<MusicianMusicPart>().Add(new MusicianMusicPart
+            {
+                Id = Guid.NewGuid(),
+                MusicianId = TestUser.Musikant.Identifier,
+                MusicPartId = assignedPart.Id
+            });
+            await db.SaveChangesAsync();
+        }
 
         var musikantClient = factory.CreateClientWithTestToken(TestUser.Musikant);
         var musikantProjects = await musikantClient.GetFromJsonAsync<List<ApiProject>>("projects", JsonDefaults.Options);

--- a/src/SheetMusic.Api.Test/Tests/Sets/CatalogPartAccessTests.cs
+++ b/src/SheetMusic.Api.Test/Tests/Sets/CatalogPartAccessTests.cs
@@ -1,0 +1,287 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SheetMusic.Api.Database;
+using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Parts;
+using SheetMusic.Api.Sets.ViewModels;
+using SheetMusic.Api.Test.Infrastructure;
+using SheetMusic.Api.Test.Infrastructure.Authentication;
+using SheetMusic.Api.Test.Utility;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SheetMusic.Api.Test.Tests.Sets;
+
+public class CatalogPartAccessTests
+{
+    [Fact]
+    public async Task GetCatalogue_ShouldFilterSetsAndParts_WhenUserIsMusikantOnly()
+    {
+        using var factory = new SheetMusicWebAppFactory();
+        var corpus = await SeedCatalogueAsync(factory);
+        var client = factory.CreateClientWithTestToken(TestUser.Musikant);
+
+        var pagedSets = await client.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets?$top=2", JsonDefaults.Options);
+        pagedSets!.Select(set => set.Id).Should().Equal(corpus.GroupSetId, corpus.SecondGroupSetId);
+        var skippedSets = await client.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets?$skip=1&$top=1", JsonDefaults.Options);
+        skippedSets!.Select(set => set.Id).Should().Equal(corpus.SecondGroupSetId);
+
+        var expandedSets = await client.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets?$expand=parts", JsonDefaults.Options);
+        expandedSets!.Select(set => set.Id).Should().BeEquivalentTo([
+            corpus.GroupSetId,
+            corpus.SecondGroupSetId,
+            corpus.DirectSetId
+        ]);
+        var expandedGroupSet = expandedSets!.Single(set => set.Id == corpus.GroupSetId);
+        expandedGroupSet.Parts!.Select(part => part.MusicPartId).Should().BeEquivalentTo([
+            corpus.GroupPartId,
+            corpus.SecondGroupPartId,
+            corpus.DirectPartId
+        ]);
+
+        var setWithParts = await client.GetFromJsonAsync<ApiSet>($"sheetmusic/sets/{corpus.GroupSetId}/parts", JsonDefaults.Options);
+        setWithParts!.Parts!.Select(part => part.MusicPartId).Should().BeEquivalentTo([
+            corpus.GroupPartId,
+            corpus.SecondGroupPartId,
+            corpus.DirectPartId
+        ]);
+
+        (await client.GetAsync($"sheetmusic/sets/{corpus.HiddenSetId}")).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        (await client.GetAsync($"sheetmusic/sets/{corpus.GroupSetId}/parts/{corpus.OutOfGroupPartId}")).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        (await client.GetAsync($"sheetmusic/sets/{corpus.HiddenSetId}/categories")).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        (await client.PostAsJsonAsync("sheetmusic/agent/chat", new { SetName = corpus.HiddenSetTitle, Question = "Composer?" })).StatusCode
+            .Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetCatalogue_ShouldReflectPartChangesOnNextRequest_WhenUserIsMusikantOnly()
+    {
+        using var factory = new SheetMusicWebAppFactory();
+        var corpus = await SeedCatalogueAsync(factory);
+        var client = factory.CreateClientWithTestToken(TestUser.Musikant);
+
+        var initialSets = await client.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets", JsonDefaults.Options);
+        initialSets!.Select(set => set.Id).Should().Contain(corpus.DirectSetId).And.NotContain(corpus.HiddenSetId);
+
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            var assignedGroupPart = await db.MusicParts.SingleAsync(part => part.Id == corpus.AssignedGroupPartId);
+            assignedGroupPart.InstrumentGroup = InstrumentGroup.Tuba;
+            var directPart = await db.MusicParts.SingleAsync(part => part.Id == corpus.DirectPartId);
+            directPart.Indexable = false;
+            await db.SaveChangesAsync();
+        }
+
+        var changedSets = await client.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets", JsonDefaults.Options);
+        changedSets!.Select(set => set.Id).Should().Contain(corpus.HiddenSetId).And.NotContain(corpus.DirectSetId);
+
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            var assignments = await db.Set<MusicianMusicPart>()
+                .Where(assignment => assignment.Musician.ApplicationUserId == TestUser.Musikant.Identifier)
+                .ToListAsync();
+            db.RemoveRange(assignments);
+            await db.SaveChangesAsync();
+        }
+
+        var setsWithoutAssignments = await client.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets", JsonDefaults.Options);
+        setsWithoutAssignments.Should().BeEmpty();
+        (await client.GetAsync($"sheetmusic/sets/{corpus.HiddenSetId}")).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetCatalogue_ShouldReturnNoAccess_WhenLinkedMusicianIsMissing()
+    {
+        using var factory = new SheetMusicWebAppFactory();
+        var corpus = await SeedCatalogueAsync(factory);
+        var client = factory.CreateClientWithTestToken(TestUser.Musikant);
+
+        var setsWithMusician = await client.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets", JsonDefaults.Options);
+        setsWithMusician!.Select(set => set.Id).Should().Contain(corpus.GroupSetId);
+
+        using (var scope = factory.TestServices.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+            var musician = await db.Musicians.SingleAsync(item => item.ApplicationUserId == TestUser.Musikant.Identifier);
+            db.Musicians.Remove(musician);
+            await db.SaveChangesAsync();
+            (await db.Musicians.AnyAsync(item => item.ApplicationUserId == TestUser.Musikant.Identifier)).Should().BeFalse();
+        }
+
+        var setsWithoutMusician = await client.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets", JsonDefaults.Options);
+        setsWithoutMusician.Should().BeEmpty();
+        (await client.GetAsync($"sheetmusic/sets/{corpus.GroupSetId}")).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task DownloadToken_ShouldRestrictIndividualPdfButAllowCompleteZip_WhenMusikantQualifiesForSet()
+    {
+        using var factory = new SheetMusicWebAppFactory();
+        var corpus = await SeedCatalogueAsync(factory);
+        var client = factory.CreateClientWithTestToken(TestUser.Musikant);
+
+        var tokenResponse = await client.GetAsync($"sheetmusic/sets/{corpus.GroupSetId}/zip/token");
+        tokenResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var token = (await tokenResponse.Content.ReadAsStringAsync()).Trim('"');
+        var anonymousClient = factory.CreateClient();
+
+        (await anonymousClient.GetAsync($"sheetmusic/sets/{corpus.GroupSetId}/parts/{corpus.OutOfGroupPartId}/pdf?downloadToken={token}"))
+            .StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var zipResponse = await anonymousClient.GetAsync($"sheetmusic/sets/{corpus.GroupSetId}/zip?downloadToken={token}");
+        zipResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        await using var zipContent = new MemoryStream(await zipResponse.Content.ReadAsByteArrayAsync());
+        using var archive = new ZipArchive(zipContent, ZipArchiveMode.Read);
+        archive.Entries.Select(entry => entry.Name).Should().BeEquivalentTo(
+            corpus.GroupSetPartNames.Select(name => $"{name}.pdf"));
+    }
+
+    [Fact]
+    public async Task GetCatalogue_ShouldNotFilter_WhenUserAlsoHasFullAccessRole()
+    {
+        using var factory = new SheetMusicWebAppFactory();
+        var corpus = await SeedCatalogueAsync(factory);
+        var client = factory.CreateClientWithTestToken(TestUser.Testesen);
+
+        var sets = await client.GetFromJsonAsync<List<ApiSet>>("sheetmusic/sets?$expand=parts", JsonDefaults.Options);
+
+        sets!.Select(set => set.Id).Should().Contain([corpus.HiddenSetId, corpus.InactiveSetId]);
+        sets!.Single(set => set.Id == corpus.GroupSetId).Parts!.Select(part => part.MusicPartId)
+            .Should().Contain(corpus.OutOfGroupPartId);
+    }
+
+    private static async Task<CatalogueCorpus> SeedCatalogueAsync(SheetMusicWebAppFactory factory)
+    {
+        _ = factory.CreateClient();
+
+        var assignedGroupPart = Part("Assigned cornet", InstrumentGroup.Kornett, indexable: false);
+        var groupPart = Part("Other cornet", InstrumentGroup.Kornett, indexable: false);
+        var assignedSecondGroupPart = Part("Assigned horn", InstrumentGroup.HornOgFlygelhorn, indexable: false);
+        var secondGroupPart = Part("Other horn", InstrumentGroup.HornOgFlygelhorn, indexable: false);
+        var outOfGroupPart = Part("Tuba", InstrumentGroup.Tuba, indexable: true);
+        var directPart = Part("Direct null group", null, indexable: true);
+        var nonIndexableDirectPart = Part("Non-indexable direct", null, indexable: false);
+        var unassignedNullPart = Part("Unassigned null group", null, indexable: true);
+
+        var groupSet = Set(1001, "Visible grouped set");
+        var hiddenSet = Set(1002, "Hidden set");
+        var secondGroupSet = Set(1003, "Second visible grouped set");
+        var inactiveSet = Set(1004, "Inactive grouped set");
+        var directSet = Set(1005, "Visible direct set");
+        var activeProject = Project("Active", DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(1));
+        var inactiveProject = Project("Inactive", DateTime.UtcNow.AddDays(-3), DateTime.UtcNow.AddDays(-2));
+
+        using var scope = factory.TestServices.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<SheetMusicContext>();
+        await db.MusicParts.AddRangeAsync(
+            assignedGroupPart,
+            groupPart,
+            assignedSecondGroupPart,
+            secondGroupPart,
+            outOfGroupPart,
+            directPart,
+            nonIndexableDirectPart,
+            unassignedNullPart);
+        await db.SheetMusicSets.AddRangeAsync(groupSet, hiddenSet, secondGroupSet, inactiveSet, directSet);
+        await db.Projects.AddRangeAsync(activeProject, inactiveProject);
+        await db.SheetMusicParts.AddRangeAsync(
+            SetPart(groupSet, groupPart),
+            SetPart(groupSet, secondGroupPart),
+            SetPart(groupSet, outOfGroupPart),
+            SetPart(groupSet, directPart),
+            SetPart(groupSet, nonIndexableDirectPart),
+            SetPart(groupSet, unassignedNullPart),
+            SetPart(hiddenSet, outOfGroupPart),
+            SetPart(secondGroupSet, groupPart),
+            SetPart(inactiveSet, groupPart),
+            SetPart(directSet, directPart));
+        await db.ProjectSheetMusicSets.AddRangeAsync(
+            Connection(activeProject, groupSet),
+            Connection(activeProject, hiddenSet),
+            Connection(activeProject, secondGroupSet),
+            Connection(inactiveProject, inactiveSet),
+            Connection(activeProject, directSet));
+        await db.Set<MusicianMusicPart>().AddRangeAsync(
+            Assignment(TestUser.Musikant.Identifier, assignedGroupPart.Id),
+            Assignment(TestUser.Musikant.Identifier, assignedSecondGroupPart.Id),
+            Assignment(TestUser.Musikant.Identifier, directPart.Id),
+            Assignment(TestUser.Musikant.Identifier, nonIndexableDirectPart.Id));
+        await db.SaveChangesAsync();
+
+        return new CatalogueCorpus(
+            groupSet.Id,
+            hiddenSet.Id,
+            hiddenSet.Title,
+            secondGroupSet.Id,
+            inactiveSet.Id,
+            directSet.Id,
+            assignedGroupPart.Id,
+            groupPart.Id,
+            secondGroupPart.Id,
+            outOfGroupPart.Id,
+            directPart.Id,
+            [groupPart.Name, secondGroupPart.Name, outOfGroupPart.Name, directPart.Name, nonIndexableDirectPart.Name, unassignedNullPart.Name]);
+    }
+
+    private static MusicPart Part(string name, InstrumentGroup? group, bool indexable) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = $"{name} {Guid.NewGuid():N}",
+        InstrumentGroup = group,
+        Indexable = indexable
+    };
+
+    private static SheetMusicSet Set(int archiveNumber, string title) => new(archiveNumber, $"{title} {Guid.NewGuid():N}");
+
+    private static Project Project(string name, DateTime startDate, DateTime endDate) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = $"{name} {Guid.NewGuid():N}",
+        StartDate = startDate,
+        EndDate = endDate
+    };
+
+    private static SheetMusicPart SetPart(SheetMusicSet set, MusicPart part) => new()
+    {
+        Id = Guid.NewGuid(),
+        SetId = set.Id,
+        MusicPartId = part.Id
+    };
+
+    private static ProjectSheetMusicSet Connection(Project project, SheetMusicSet set) => new()
+    {
+        Id = Guid.NewGuid(),
+        ProjectId = project.Id,
+        SheetMusicSetId = set.Id
+    };
+
+    private static MusicianMusicPart Assignment(Guid musicianId, Guid partId) => new()
+    {
+        Id = Guid.NewGuid(),
+        MusicianId = musicianId,
+        MusicPartId = partId
+    };
+
+    private sealed record CatalogueCorpus(
+        Guid GroupSetId,
+        Guid HiddenSetId,
+        string HiddenSetTitle,
+        Guid SecondGroupSetId,
+        Guid InactiveSetId,
+        Guid DirectSetId,
+        Guid AssignedGroupPartId,
+        Guid GroupPartId,
+        Guid SecondGroupPartId,
+        Guid OutOfGroupPartId,
+        Guid DirectPartId,
+        IReadOnlyList<string> GroupSetPartNames);
+}

--- a/src/SheetMusic.Api/BlobStorage/BlobClient.cs
+++ b/src/SheetMusic.Api/BlobStorage/BlobClient.cs
@@ -37,18 +37,17 @@ public class BlobClient(BlobServiceClient blobServiceClient, IConfiguration conf
     public async Task<byte[]> GetMusicPartContentAsync(PartRelatedToSet identifier)
     {
         var blob = GetBlob(identifier);
-
         using var memoryStream = new MemoryStream();
         await blob.DownloadToAsync(memoryStream);
         await memoryStream.FlushAsync();
         return memoryStream.ToArray();
     }
 
-    public async Task<Stream> GetMusicPartContentStreamAsync(PartRelatedToSet identifier)
+    public async Task<Stream> GetMusicPartContentStreamAsync(PartRelatedToSet identifier, CancellationToken cancellationToken = default)
     {
         var blob = GetBlob(identifier);
 
-        return await blob.OpenReadAsync();
+        return await blob.OpenReadAsync(cancellationToken: cancellationToken);
     }
 
     public async Task AddMusicPartContentAsync(PartRelatedToSet identifier, Stream contentStream, CancellationToken cancellationToken)

--- a/src/SheetMusic.Api/BlobStorage/IBlobClient.cs
+++ b/src/SheetMusic.Api/BlobStorage/IBlobClient.cs
@@ -11,7 +11,7 @@ public interface IBlobClient
     Task AddMusicPartContentAsync(PartRelatedToSet identifier, Stream contentStream, CancellationToken cancellationToken);
     Task EnsureContainerExistsAsync();
     Task<byte[]> GetMusicPartContentAsync(PartRelatedToSet identifier);
-    Task<Stream> GetMusicPartContentStreamAsync(PartRelatedToSet identifier);
+    Task<Stream> GetMusicPartContentStreamAsync(PartRelatedToSet identifier, CancellationToken cancellationToken = default);
     Task DeleteSetContentAsync(Guid id);
     Task<bool> HasPdfFileAsync(PartRelatedToSet identifier);
     Task DeletePartContentAsync(PartRelatedToSet identifier);

--- a/src/SheetMusic.Api/Sets/Queries/GetPartsForSet.cs
+++ b/src/SheetMusic.Api/Sets/Queries/GetPartsForSet.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
 using SheetMusic.Api.Database.Entities;
+using SheetMusic.Api.Users.Authorization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,7 +15,7 @@ public class GetPartsForSet(Guid setId) : IRequest<List<SheetMusicPart>>
 {
     public Guid SetId { get; } = setId;
 
-    public class Handler(SheetMusicContext db) : IRequestHandler<GetPartsForSet, List<SheetMusicPart>>
+    public class Handler(SheetMusicContext db, CatalogAccessService catalogAccess) : IRequestHandler<GetPartsForSet, List<SheetMusicPart>>
     {
         public async Task<List<SheetMusicPart>> Handle(GetPartsForSet request, CancellationToken cancellationToken)
         {
@@ -23,7 +24,7 @@ public class GetPartsForSet(Guid setId) : IRequest<List<SheetMusicPart>>
                         where set.Id == request.SetId
                         select setPart;
 
-            var items = await query
+            var items = await catalogAccess.FilterAccessibleParts(query)
                 .Include(sp => sp.Set)
                 .Include(sp => sp.Part)
                 .OrderBy(sp => sp.Part.SortOrder)

--- a/src/SheetMusic.Api/Sets/Queries/GetPartsZipAsStream.cs
+++ b/src/SheetMusic.Api/Sets/Queries/GetPartsZipAsStream.cs
@@ -30,8 +30,8 @@ public class GetPartsZipAsStream(string setIdentifier) : IRequest<Stream>
                 var entry = zip.CreateEntry($"{partRelation.Part.Name}.pdf");
                 using var entryStream = entry.Open();
                 var id = new PartRelatedToSet(set.Id, partRelation.MusicPartId);
-                var contents = await blobClient.GetMusicPartContentStreamAsync(id);
-                contents.CopyTo(entryStream);
+                await using var contents = await blobClient.GetMusicPartContentStreamAsync(id, cancellationToken);
+                await contents.CopyToAsync(entryStream, cancellationToken);
 
                 await entryStream.FlushAsync(cancellationToken);
             }

--- a/src/SheetMusic.Api/Sets/Queries/GetSets.cs
+++ b/src/SheetMusic.Api/Sets/Queries/GetSets.cs
@@ -6,6 +6,7 @@ using SheetMusic.Api.OData;
 using SheetMusic.Api.OData.Expression;
 using SheetMusic.Api.OData.Extensions;
 using SheetMusic.Api.OData.MVC;
+using SheetMusic.Api.Users.Authorization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,7 +21,7 @@ public class GetSets(ODataQueryParams queryParams, Guid? categoryId = null, bool
     public Guid? CategoryId { get; } = categoryId;
     public bool IncludeProjects { get; } = includeProjects;
 
-    public class Handler(SheetMusicContext db) : IRequestHandler<GetSets, List<SheetMusicSet>>
+    public class Handler(SheetMusicContext db, CatalogAccessService catalogAccess) : IRequestHandler<GetSets, List<SheetMusicSet>>
     {
         private static readonly Action<ODataFieldMapping<SheetMusicSet>> FieldMapping = m =>
         {
@@ -33,7 +34,7 @@ public class GetSets(ODataQueryParams queryParams, Guid? categoryId = null, bool
 
         public async Task<List<SheetMusicSet>> Handle(GetSets request, CancellationToken cancellationToken)
         {
-            var baseQuery = db.SheetMusicSets.AsQueryable();
+            var baseQuery = catalogAccess.FilterAccessibleSets(db.SheetMusicSets);
 
             if (request.QueryParams.HasFilter)
                 baseQuery = baseQuery.ApplyODataFilters(request.QueryParams, FieldMapping);

--- a/src/SheetMusic.Api/Sets/SheetMusicController.cs
+++ b/src/SheetMusic.Api/Sets/SheetMusicController.cs
@@ -17,6 +17,7 @@ using SheetMusic.Api.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SheetMusic.Api.Sets;
@@ -46,6 +47,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// </summary>
     /// <param name="queryParams">Optional. OData support for $filter and $expand=parts,projects</param>
     /// <param name="category">Optional. Filter sets by category, identified by guid or name</param>
+    /// <param name="cancellationToken">The request cancellation token</param>
     /// <returns>Sets matching criteria</returns>
     /// <response code="200">A list of sets matching filter, or all sets. Empty list if no matching results</response>
     /// <response code="400">If an unsupported $expand value is provided</response>
@@ -53,10 +55,10 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <response code="401">Authorization header (bearer token) is invalid</response>
     [Produces("application/json", Type = typeof(List<ApiSet>))]
     [HttpGet("sets")]
-    public Task<IActionResult> GetSetList(ODataQueryParams queryParams, string? category) =>
-        GetSetListInternal(queryParams, category);
+    public Task<IActionResult> GetSetList(ODataQueryParams queryParams, string? category, CancellationToken cancellationToken) =>
+        GetSetListInternal(queryParams, category, cancellationToken);
 
-    private async Task<IActionResult> GetSetListInternal(ODataQueryParams queryParams, string? category)
+    private async Task<IActionResult> GetSetListInternal(ODataQueryParams queryParams, string? category, CancellationToken cancellationToken)
     {
         var unsupportedExpands = queryParams.Expand
             .Where(e => !SupportedSetExpand.Split(", ").Contains(e, StringComparer.OrdinalIgnoreCase))
@@ -72,7 +74,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
         if (!string.IsNullOrWhiteSpace(category))
         {
-            var matchedCategory = await mediator.Send(new GetCategory(category));
+            var matchedCategory = await mediator.Send(new GetCategory(category), cancellationToken);
 
             if (matchedCategory is null)
                 return NotFound(new ProblemDetails { Detail = $"Category '{category}' was not found" });
@@ -80,15 +82,17 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
             categoryId = matchedCategory.Id;
         }
 
-        var matchingSets = await mediator.Send(new GetSets(queryParams, categoryId, expandProjects));
-        var accessibleSetIds = await catalogAccess.GetAccessibleSetIdsAsync(matchingSets.Select(set => set.Id));
+        var matchingSets = await mediator.Send(new GetSets(queryParams, categoryId, expandProjects), cancellationToken);
+        var accessiblePartIds = expandParts
+            ? await catalogAccess.GetAccessiblePartIdsAsync(matchingSets.Select(set => set.Id), cancellationToken)
+            : [];
 
-        var transformed = matchingSets.Where(set => accessibleSetIds.Contains(set.Id)).Select(s => new ApiSet(s)
+        var transformed = matchingSets.Select(s => new ApiSet(s)
             {
                 ZipDownloadUrl = $"{BaseUrl}/sets/{s.Id}/zip",
                 PartsUrl = $"{BaseUrl}/sets/{s.Id}/parts",
                 Parts = expandParts ?
-                    s.Parts.Select(p => new ApiSheetMusicPart(p)
+                    s.Parts.Where(part => accessiblePartIds.Contains(part.Id)).Select(p => new ApiSheetMusicPart(p)
                     {
                         PdfDownloadUrl = $"{BaseUrl}/sets/{p.SetId}/parts/{p.MusicPartId}/pdf",
                         DeletePartUrl = $"{BaseUrl}/sets/{p.SetId}/parts/{p.MusicPartId}"
@@ -110,24 +114,26 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// Lists parts for set with <paramref name="identifier"/> 
     /// </summary>
     /// <param name="identifier">A value uniquely identifying set. Either guid, archive number or title</param>
+    /// <param name="cancellationToken">The request cancellation token</param>
     /// <returns>List of parts for set</returns>
     /// <response code="200">Set information including its parts</response>
     /// <response code="404">Set not found</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">The caller cannot access the requested set</response>
     [Produces("application/json", Type = typeof(ApiSet))]
     [HttpGet("sets/{identifier}/parts")]
-    public async Task<ActionResult<ApiSet>> GetPartsForSet(string identifier)
+    public async Task<ActionResult<ApiSet>> GetPartsForSet(string identifier, CancellationToken cancellationToken)
     {
-        var set = await mediator.Send(new GetSet(identifier));
+        var set = await mediator.Send(new GetSet(identifier), cancellationToken);
 
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{identifier}' was not found" });
 
-        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+        if (!await catalogAccess.CanAccessSetAsync(set.Id, cancellationToken))
             return Forbid();
 
         var query = new GetPartsForSet(set.Id);
-        var parts = await mediator.Send(query);
+        var parts = await mediator.Send(query, cancellationToken);
 
         var apiSet = new ApiSet(set)
         {
@@ -147,20 +153,22 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// </summary>
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="partIdentifier">A value uniquely identifying part. Either guid or part name</param>
+    /// <param name="cancellationToken">The request cancellation token</param>
     /// <returns>The part that matches, 404 if not found</returns>
     /// <response code="200">The part matching the identifiers</response>
     /// <response code="404">Set, part, or the relationship between them was not found</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">The caller cannot access the requested part</response>
     [Produces("application/json", Type = typeof(ApiSheetMusicPart))]
     [HttpGet("sets/{setIdentifier}/parts/{partIdentifier}")]
-    public async Task<IActionResult> GetSinglePart(string setIdentifier, string partIdentifier)
+    public async Task<IActionResult> GetSinglePart(string setIdentifier, string partIdentifier, CancellationToken cancellationToken)
     {
-        var partOnSet = await mediator.Send(new GetPartOnSet(setIdentifier, partIdentifier));
+        var partOnSet = await mediator.Send(new GetPartOnSet(setIdentifier, partIdentifier), cancellationToken);
 
         if (partOnSet == null)
             return NotFound(new ProblemDetails { Detail = $"Relationship between '{setIdentifier}' and '{partIdentifier}' was not found" });
 
-        if (!await catalogAccess.CanAccessSetAsync(partOnSet.SetId))
+        if (!await catalogAccess.CanAccessPartAsync(partOnSet.SetId, partOnSet.MusicPartId, cancellationToken))
             return Forbid();
 
         return new OkObjectResult(new ApiSheetMusicPart(partOnSet));
@@ -172,6 +180,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="partIdentifier">A value uniquely identifying part. Either guid or part name</param>
     /// <param name="downloadToken">A token to prove you are authorized for download</param>
+    /// <param name="cancellationToken">The request cancellation token</param>
     /// <returns>The PDF file, if it exists. 404 otherwise.</returns>
     /// <response code="200">The PDF file content</response>
     /// <response code="400">If the download token is missing or invalid</response>
@@ -179,16 +188,19 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     [AllowAnonymous]
     [Produces("application/pdf")]
     [HttpGet("sets/{setIdentifier}/parts/{partIdentifier}/pdf")]
-    public async Task<IActionResult> GetSinglePartFile(string setIdentifier, string partIdentifier, string downloadToken)
+    public async Task<IActionResult> GetSinglePartFile(string setIdentifier, string partIdentifier, string downloadToken, CancellationToken cancellationToken)
     {
-        var partOnSet = await mediator.Send(new GetPartOnSet(setIdentifier, partIdentifier));
+        var partOnSet = await mediator.Send(new GetPartOnSet(setIdentifier, partIdentifier), cancellationToken);
 
         if (partOnSet == null)
             return NotFound(new ProblemDetails { Detail = $"Relationship between '{setIdentifier}' and '{partIdentifier}' was not found" });
 
-        if (string.IsNullOrEmpty(downloadToken) || !TryConsumeDownloadToken(partOnSet.SetId, downloadToken))
+        if (string.IsNullOrEmpty(downloadToken) ||
+            !TryGetDownloadAuthorization(partOnSet.SetId, downloadToken, out var authorization) ||
+            !await catalogAccess.CanUserAccessPartAsync(authorization.UserId, partOnSet.SetId, partOnSet.MusicPartId, cancellationToken) ||
+            !TryConsumeDownloadToken(partOnSet.SetId, downloadToken))
         {
-            return new BadRequestObjectResult("Download token must be provided and valid");
+            return BadRequest();
         }
 
         var pdf = await blobClient.GetMusicPartContentAsync(new PartRelatedToSet(partOnSet.SetId, partOnSet.MusicPartId));
@@ -200,20 +212,22 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// Gets information about a single set, either by guid, number or title.
     /// </summary>
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
+    /// <param name="cancellationToken">The request cancellation token</param>
     /// <returns>Set matching <paramref name="setIdentifier"/></returns>
     /// <response code="200">The set matching the identifier</response>
     /// <response code="404">Set not found</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">The caller cannot access the requested set</response>
     [Produces("application/json", Type = typeof(ApiSet))]
     [HttpGet("sets/{setIdentifier}")]
-    public async Task<IActionResult> GetSetinformationByIdentifier(string setIdentifier)
+    public async Task<IActionResult> GetSetinformationByIdentifier(string setIdentifier, CancellationToken cancellationToken)
     {
-        var set = await mediator.Send(new GetSet(setIdentifier));
+        var set = await mediator.Send(new GetSet(setIdentifier), cancellationToken);
 
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{setIdentifier}' was not found" });
 
-        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+        if (!await catalogAccess.CanAccessSetAsync(set.Id, cancellationToken))
             return Forbid();
 
         return new OkObjectResult(new ApiSet(set)
@@ -241,7 +255,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{request.SetName}' was not found" });
 
-        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+        if (!await catalogAccess.CanAccessSetAsync(set.Id, cancellationToken))
             return Forbid();
 
         return new ApiSetAgentResponse(await agent.AnswerSetQuestionAsync(set, request.Question, cancellationToken));
@@ -257,6 +271,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// <response code="400">If provided input is invalid. Should include a body with ProblemDetails-formatted errors.</response>
     /// <response code="404">Set not found</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">The caller cannot access the requested set</response>
     /// <response code="403">Forbidden. User does not have required privileges (Noteansvarlig or Administrator)</response>
     [Produces("application/json", Type = typeof(ApiSet))]
     [Authorize(AuthPolicy.ManageMusic)]
@@ -282,20 +297,22 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// Gets the categories assigned to set with <paramref name="setIdentifier"/>
     /// </summary>
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
+    /// <param name="cancellationToken">The request cancellation token</param>
     /// <returns>List of categories assigned to the set</returns>
     /// <response code="200">List of categories assigned to the set</response>
     /// <response code="404">Set not found</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">The caller cannot access the requested set</response>
     [Produces("application/json", Type = typeof(List<ApiCategory>))]
     [HttpGet("sets/{setIdentifier}/categories")]
-    public async Task<IActionResult> GetCategoriesForSet(string setIdentifier)
+    public async Task<IActionResult> GetCategoriesForSet(string setIdentifier, CancellationToken cancellationToken)
     {
-        var set = await mediator.Send(new GetSet(setIdentifier));
+        var set = await mediator.Send(new GetSet(setIdentifier), cancellationToken);
 
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{setIdentifier}' was not found" });
 
-        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+        if (!await catalogAccess.CanAccessSetAsync(set.Id, cancellationToken))
             return Forbid();
 
         var categories = set.Categories.Where(c => c.Category != null).Select(c => new ApiCategory(c.Category)).ToList();
@@ -354,24 +371,30 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// Authorized a set for download, allowing a single download for the one with the token.
     /// </summary>
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
+    /// <param name="cancellationToken">The request cancellation token</param>
     /// <returns>A one-time download token</returns>
     /// <response code="200">The generated download token</response>
     /// <response code="404">Set not found</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
+    /// <response code="403">The caller cannot access the requested set</response>
     [HttpGet("sets/{setIdentifier}/zip/token")]
-    public async Task<IActionResult> GetDownloadToken(string setIdentifier)
+    public async Task<IActionResult> GetDownloadToken(string setIdentifier, CancellationToken cancellationToken)
     {
-        var set = await mediator.Send(new GetSet(setIdentifier));
+        var set = await mediator.Send(new GetSet(setIdentifier), cancellationToken);
 
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{setIdentifier}' was not found" });
 
-        if (!await catalogAccess.CanAccessSetAsync(set.Id))
+        if (!await catalogAccess.CanAccessSetAsync(set.Id, cancellationToken))
+            return Forbid();
+
+        var userId = catalogAccess.CurrentUserId;
+        if (userId is null)
             return Forbid();
 
         //generated token using cryptographic library, save to memory cache and verify on download
         var token = KeyGenerator.GetUniqueKey(64);
-        memoryCache.Set(DownloadTokenCacheKey(token), set.Id, TimeSpan.FromMinutes(60));
+        memoryCache.Set(DownloadTokenCacheKey(token), new DownloadAuthorization(set.Id, userId.Value), TimeSpan.FromMinutes(60));
 
         return new OkObjectResult(token);
     }
@@ -382,6 +405,7 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// </summary>
     /// <param name="setIdentifier">A value uniquely identifying set. Either guid, archive number or title</param>
     /// <param name="downloadToken">A token for proving that user is allowed to download this set</param>
+    /// <param name="cancellationToken">The request cancellation token</param>
     /// <returns>Zipped collection of parts</returns>
     /// <response code="200">The zipped collection of parts</response>
     /// <response code="400">If the download token is missing or invalid</response>
@@ -389,9 +413,9 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     [AllowAnonymous]
     [Produces("application/zip")]
     [HttpGet("sets/{setIdentifier}/zip")]
-    public async Task<IActionResult> GetPartsForSetAzZip(string setIdentifier, string downloadToken)
+    public async Task<IActionResult> GetPartsForSetAzZip(string setIdentifier, string downloadToken, CancellationToken cancellationToken)
     {
-        var set = await mediator.Send(new GetSet(setIdentifier));
+        var set = await mediator.Send(new GetSet(setIdentifier), cancellationToken);
 
         if (set is null)
             return NotFound(new ProblemDetails { Detail = $"Set '{setIdentifier}' was not found" });
@@ -401,8 +425,8 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
             return new BadRequestObjectResult("Download token must be provided and valid");
         }
 
-        var zipStream = await mediator.Send(new GetPartsZipAsStream(setIdentifier));
-        await zipStream.FlushAsync();
+        var zipStream = await mediator.Send(new GetPartsZipAsStream(setIdentifier), cancellationToken);
+        await zipStream.FlushAsync(cancellationToken);
         zipStream.Position = 0;
 
         return File(zipStream, "application/zip", $"{set.Title}.zip");
@@ -412,25 +436,26 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
     /// Analyzes the assigned parts and compares them with the blob storage content. 
     /// If a non-empty file does not exists, the set is listed in results
     /// </summary>
+    /// <param name="cancellationToken">The request cancellation token</param>
     /// <returns>The sets with parts that are assigned, but a file is not present</returns>
     /// <response code="200">The sets with parts that are assigned, but a file is not present</response>
     /// <response code="401">Authorization header (bearer token) is invalid</response>
     [Produces("application/json")]
     [HttpGet("sets/withoutFiles")]
-    public async Task<IActionResult> GetSetsThatHasPartsButNoFiles()
+    public async Task<IActionResult> GetSetsThatHasPartsButNoFiles(CancellationToken cancellationToken)
     {
         var queryParams = new ODataQueryParams();
         queryParams.Expand.Add("parts");
 
-        var setsWithParts = await mediator.Send(new GetSets(queryParams));
-        var accessibleSetIds = await catalogAccess.GetAccessibleSetIdsAsync(setsWithParts.Select(set => set.Id));
+        var setsWithParts = await mediator.Send(new GetSets(queryParams), cancellationToken);
+        var accessiblePartIds = await catalogAccess.GetAccessiblePartIdsAsync(setsWithParts.Select(set => set.Id), cancellationToken);
         var results = new List<ApiSet>();
 
-        foreach (var setWithParts in setsWithParts.Where(set => accessibleSetIds.Contains(set.Id)))
+        foreach (var setWithParts in setsWithParts)
         {
             var apiSet = new ApiSet(setWithParts);
 
-            foreach (var part in setWithParts.Parts)
+            foreach (var part in setWithParts.Parts.Where(part => accessiblePartIds.Contains(part.Id)))
             {
                 if (await blobClient.HasPdfFileAsync(new PartRelatedToSet(setWithParts.Id, part.MusicPartId)) == false)
                 {
@@ -690,11 +715,26 @@ public class SheetMusicController(IBlobClient blobClient, IMemoryCache memoryCac
 
     private static string DownloadTokenCacheKey(string token) => $"Download_{token}";
 
+    private sealed record DownloadAuthorization(Guid SetId, Guid UserId);
+
+    private bool TryGetDownloadAuthorization(Guid setId, string providedToken, out DownloadAuthorization authorization)
+    {
+        if (memoryCache.TryGetValue(DownloadTokenCacheKey(providedToken), out DownloadAuthorization? cachedAuthorization) &&
+            cachedAuthorization?.SetId == setId)
+        {
+            authorization = cachedAuthorization;
+            return true;
+        }
+
+        authorization = null!;
+        return false;
+    }
+
     private bool TryConsumeDownloadToken(Guid setId, string providedToken)
     {
         lock (DownloadTokenLock)
         {
-            if (memoryCache.TryGetValue(DownloadTokenCacheKey(providedToken), out Guid tokenSetId) && tokenSetId == setId)
+            if (memoryCache.TryGetValue(DownloadTokenCacheKey(providedToken), out DownloadAuthorization? authorization) && authorization?.SetId == setId)
             {
                 memoryCache.Remove(DownloadTokenCacheKey(providedToken));
                 return true;

--- a/src/SheetMusic.Api/Users/Authorization/CatalogAccessService.cs
+++ b/src/SheetMusic.Api/Users/Authorization/CatalogAccessService.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using SheetMusic.Api.Database;
+using SheetMusic.Api.Database.Entities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,20 +16,70 @@ namespace SheetMusic.Api.Users.Authorization;
 /// </summary>
 public class CatalogAccessService(SheetMusicContext db, IHttpContextAccessor httpContextAccessor)
 {
-    /// <summary>Gets whether the current user can access the specified set.</summary>
-    public async Task<bool> CanAccessSetAsync(Guid setId, CancellationToken cancellationToken = default)
+    /// <summary>Gets the current catalogue user's identifier.</summary>
+    public Guid? CurrentUserId => GetUserId();
+
+    /// <summary>Filters sets to the catalogue resources visible to the current user.</summary>
+    public IQueryable<SheetMusicSet> FilterAccessibleSets(IQueryable<SheetMusicSet> sets)
     {
         if (HasFullLibraryAccess())
+            return sets;
+
+        var userId = GetUserId();
+        if (!IsMusikant() || userId is null)
+            return sets.Where(_ => false);
+
+        var now = DateTime.UtcNow;
+        var permittedParts = FilterPartsForMusikant(db.SheetMusicParts, userId.Value);
+
+        return sets.Where(set =>
+            set.ProjectConnections.Any(connection =>
+                connection.Project.StartDate <= now && connection.Project.EndDate >= now) &&
+            permittedParts.Any(part => part.SetId == set.Id));
+    }
+
+    /// <summary>Filters set parts to the catalogue resources visible to the current user.</summary>
+    public IQueryable<SheetMusicPart> FilterAccessibleParts(IQueryable<SheetMusicPart> parts)
+    {
+        if (HasFullLibraryAccess())
+            return parts;
+
+        var userId = GetUserId();
+        if (!IsMusikant() || userId is null)
+            return parts.Where(_ => false);
+
+        return FilterPartsForMusikant(parts, userId.Value);
+    }
+
+    /// <summary>Gets whether the current user can access the specified set.</summary>
+    public Task<bool> CanAccessSetAsync(Guid setId, CancellationToken cancellationToken = default) =>
+        FilterAccessibleSets(db.SheetMusicSets).AnyAsync(set => set.Id == setId, cancellationToken);
+
+    /// <summary>Gets whether the current user can access the specified part on a set.</summary>
+    public async Task<bool> CanAccessPartAsync(Guid setId, Guid musicPartId, CancellationToken cancellationToken = default) =>
+        await FilterAccessibleSets(db.SheetMusicSets).AnyAsync(set => set.Id == setId, cancellationToken) &&
+        await FilterAccessibleParts(db.SheetMusicParts).AnyAsync(part =>
+            part.SetId == setId && part.MusicPartId == musicPartId,
+            cancellationToken);
+
+    /// <summary>Gets whether a user can currently access the specified part on a set.</summary>
+    public async Task<bool> CanUserAccessPartAsync(Guid userId, Guid setId, Guid musicPartId, CancellationToken cancellationToken = default)
+    {
+        var roles = db.UserRoles
+            .Where(userRole => userRole.UserId == userId)
+            .Join(db.Roles, userRole => userRole.RoleId, role => role.Id, (_, role) => role.Name);
+
+        if (await roles.AnyAsync(role => role == Roles.Admin || role == Roles.Noteansvarlig || role == Roles.Arkivleser, cancellationToken))
             return true;
 
-        if (!IsMusikant())
+        if (!await roles.AnyAsync(role => role == Roles.Musikant, cancellationToken))
             return false;
 
         var now = DateTime.UtcNow;
-        return await db.ProjectSheetMusicSets.AnyAsync(connection =>
-            connection.SheetMusicSetId == setId &&
-            connection.Project.StartDate <= now &&
-            connection.Project.EndDate >= now,
+        return await FilterPartsForMusikant(db.SheetMusicParts, userId).AnyAsync(part =>
+            part.SetId == setId && part.MusicPartId == musicPartId &&
+            part.Set.ProjectConnections.Any(connection =>
+                connection.Project.StartDate <= now && connection.Project.EndDate >= now),
             cancellationToken);
     }
 
@@ -40,19 +91,36 @@ public class CatalogAccessService(SheetMusicContext db, IHttpContextAccessor htt
     public async Task<HashSet<Guid>> GetAccessibleSetIdsAsync(IEnumerable<Guid> setIds, CancellationToken cancellationToken = default)
     {
         var ids = setIds.ToList();
-        if (HasFullLibraryAccess())
-            return [.. ids];
-
-        if (!IsMusikant())
-            return [];
-
-        var now = DateTime.UtcNow;
-        return [.. await db.ProjectSheetMusicSets
-            .Where(connection => ids.Contains(connection.SheetMusicSetId) &&
-                connection.Project.StartDate <= now && connection.Project.EndDate >= now)
-            .Select(connection => connection.SheetMusicSetId)
+        return [.. await FilterAccessibleSets(db.SheetMusicSets)
+            .Where(set => ids.Contains(set.Id))
+            .Select(set => set.Id)
             .ToListAsync(cancellationToken)];
     }
+
+    /// <summary>Filters part relationship identifiers to the catalogue resources visible to the current user.</summary>
+    public async Task<HashSet<Guid>> GetAccessiblePartIdsAsync(IEnumerable<Guid> setIds, CancellationToken cancellationToken = default)
+    {
+        var ids = setIds.ToList();
+        return [.. await FilterAccessibleParts(db.SheetMusicParts)
+            .Where(part => ids.Contains(part.SetId))
+            .Select(part => part.Id)
+            .ToListAsync(cancellationToken)];
+    }
+
+    private IQueryable<SheetMusicPart> FilterPartsForMusikant(IQueryable<SheetMusicPart> parts, Guid userId)
+    {
+        var assignments = db.Set<MusicianMusicPart>()
+            .Where(assignment => assignment.Musician.ApplicationUserId == userId);
+
+        return parts.Where(part =>
+            part.Part.InstrumentGroup != null && assignments.Any(assignment =>
+                assignment.MusicPart.InstrumentGroup != null &&
+                assignment.MusicPart.InstrumentGroup == part.Part.InstrumentGroup) ||
+            part.Part.InstrumentGroup == null && part.Part.Indexable && assignments.Any(assignment =>
+                assignment.MusicPartId == part.MusicPartId));
+    }
+
+    private Guid? GetUserId() => Guid.TryParse(User.Identity?.Name, out var userId) ? userId : null;
 
     private bool HasFullLibraryAccess() => User.IsInRole(Roles.Admin) || User.IsInRole(Roles.Noteansvarlig) || User.IsInRole(Roles.Arkivleser);
 


### PR DESCRIPTION
## Summary
- filter Musikant set visibility by active projects and live assigned instrument groups before OData paging
- filter expanded, listed, and individual parts while preserving full-access role precedence
- revalidate individual PDF access from the token issuer's current database permissions while keeping complete set ZIP downloads available
- propagate cancellation through catalogue reads and ZIP generation
- add integration coverage for multi-group, null-group, paging, missing-musician, role-precedence, direct-access, and ZIP behavior

## Testing
- `dotnet build src/SheetMusic.sln --no-restore`
- affected integration suites: 187 passed, 0 failed

Closes #378